### PR TITLE
Xen read physical

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2018"
 [dependencies]
 xenctrl = { version = "0.1.0", path = "../xenctrl" }
 xenstore = { version = "0.1.0", path = "../xenstore" }
+xenforeignmemory = { version = "0.1.0", path = "../xenforeignmemory" }
+libc = "0.2.58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ xenctrl = { version = "0.1.0", path = "../xenctrl" }
 xenstore = { version = "0.1.0", path = "../xenstore" }
 xenforeignmemory = { version = "0.1.0", path = "../xenforeignmemory" }
 libc = "0.2.58"
+
+[[bin]]
+name = "mem-dump"
+path = "src/bin/mem-dump.rs"

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,6 +4,9 @@ pub enum DriverType {
 }
 
 pub trait Introspectable {
+    // read physical memory
+    fn read_physical(&self, paddr: u64, count: u32) -> Result<Vec<u8>,&str>;
+
     // pause the VM
     fn pause(&self);
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,6 +7,9 @@ pub trait Introspectable {
     // read physical memory
     fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),&str>;
 
+    // get max physical address
+    fn get_max_physical_addr(&self) -> Result<u64,&str>;
+
     // pause the VM
     fn pause(&self);
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,7 @@ pub enum DriverType {
 
 pub trait Introspectable {
     // read physical memory
-    fn read_physical(&self, paddr: u64, count: u32) -> Result<Vec<u8>,&str>;
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),&str>;
 
     // pause the VM
     fn pause(&self);

--- a/src/bin/mem-dump.rs
+++ b/src/bin/mem-dump.rs
@@ -32,7 +32,7 @@ fn main() {
     let max_addr = drv.get_max_physical_addr().unwrap();
     println!("Max address @{:x}", max_addr);
     println!("Dumping physical memory to {}", dump_path.display());
-    while cur_addr < max_addr {
+    for cur_addr in (0..max_addr).step_by(PAGE_SIZE) {
         let result = drv.read_physical(cur_addr, &mut buffer);
         match result {
             Ok(()) => {
@@ -41,7 +41,6 @@ fn main() {
             },
             Err(_error) => (),
         }
-        cur_addr += PAGE_SIZE as u64;
     }
 
     println!("resuming the VM");

--- a/src/bin/mem-dump.rs
+++ b/src/bin/mem-dump.rs
@@ -1,4 +1,7 @@
 use std::env;
+use std::path::Path;
+use std::fs::File;
+use std::io::Write;
 extern crate microvmi;
 
 // traits method can only be used if the trait is in the scope
@@ -14,6 +17,9 @@ fn main() {
         return;
     }
     let domain_name = &args[1];
+    let dump_name = format!("{}.dump", domain_name);
+    let dump_path = Path::new(&dump_name);
+    let mut dump_file = File::create(dump_path).expect("Fail to open dump file");
 
     let drv_type = DriverType::Xen;
     let drv: Box<Introspectable> = microvmi::init(drv_type, domain_name);
@@ -25,11 +31,15 @@ fn main() {
     let mut cur_addr: u64 = 0;
     let max_addr = drv.get_max_physical_addr().unwrap();
     println!("Max address @{:x}", max_addr);
+    println!("Dumping physical memory to {}", dump_path.display());
     while cur_addr < max_addr {
         let result = drv.read_physical(cur_addr, &mut buffer);
         match result {
-            Ok(()) => println!("page read success 0x{:x}", cur_addr),
-            Err(error) => println!("page read failed 0x{:x}", cur_addr),
+            Ok(()) => {
+                dump_file.write(&buffer).expect("failed to write to file");
+                ()
+            },
+            Err(_error) => (),
         }
         cur_addr += PAGE_SIZE as u64;
     }

--- a/src/bin/mem-dump.rs
+++ b/src/bin/mem-dump.rs
@@ -1,11 +1,11 @@
 use std::env;
-use std::thread;
-use std::time;
 extern crate microvmi;
 
 // traits method can only be used if the trait is in the scope
 use microvmi::api::Introspectable;
 use microvmi::api::DriverType;
+
+const PAGE_SIZE: usize = 4096;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -18,13 +18,22 @@ fn main() {
     let drv_type = DriverType::Xen;
     let drv: Box<Introspectable> = microvmi::init(drv_type, domain_name);
 
-    // play with pause and resume
     println!("pausing the VM");
     drv.pause();
-    println!("waiting 5 seconds...");
-    let duration = time::Duration::from_millis(5000);
-    thread::sleep(duration);
+
+    let mut buffer: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
+    let mut cur_addr: u64 = 0;
+    let max_addr = drv.get_max_physical_addr().unwrap();
+    println!("Max address @{:x}", max_addr);
+    while cur_addr < max_addr {
+        let result = drv.read_physical(cur_addr, &mut buffer);
+        match result {
+            Ok(()) => println!("page read success 0x{:x}", cur_addr),
+            Err(error) => println!("page read failed 0x{:x}", cur_addr),
+        }
+        cur_addr += PAGE_SIZE as u64;
+    }
+
     println!("resuming the VM");
     drv.resume();
-
 }

--- a/src/driver/dummy.rs
+++ b/src/driver/dummy.rs
@@ -13,9 +13,9 @@ impl Dummy {
 }
 
 impl api::Introspectable for Dummy {
-    fn read_physical(&self, paddr: u64, count: u32) -> Result<Vec<u8>,&str> {
-        println!("dummy read physical - @{}, count: {}", paddr, count);
-        Ok(Vec::new())
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),&str> {
+        println!("dummy read physical - @{}, {:#?}", paddr, buf);
+        Ok(())
     }
 
     fn pause(&self) {

--- a/src/driver/dummy.rs
+++ b/src/driver/dummy.rs
@@ -18,6 +18,11 @@ impl api::Introspectable for Dummy {
         Ok(())
     }
 
+    fn get_max_physical_addr(&self) -> Result<u64,&str> {
+        println!("dummy get max physical address");
+        Ok(0)
+    }
+
     fn pause(&self) {
         println!("dummy pause");
     }

--- a/src/driver/dummy.rs
+++ b/src/driver/dummy.rs
@@ -13,6 +13,11 @@ impl Dummy {
 }
 
 impl api::Introspectable for Dummy {
+    fn read_physical(&self, paddr: u64, count: u32) -> Result<Vec<u8>,&str> {
+        println!("dummy read physical - @{}, count: {}", paddr, count);
+        Ok(Vec::new())
+    }
+
     fn pause(&self) {
         println!("dummy pause");
     }

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -87,6 +87,11 @@ impl api::Introspectable for Xen {
         Ok(())
     }
 
+    fn get_max_physical_addr(&self) -> Result<u64,&str> {
+        let max_gpfn = self.xc.domain_maximum_gpfn(self.domid).unwrap();
+        Ok(max_gpfn << xenctrl::PAGE_SHIFT)
+    }
+
     fn pause(&self) {
         println!("Xen driver pause");
         self.xc.domain_pause(self.domid).unwrap();

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -68,7 +68,7 @@ impl api::Introspectable for Xen {
             let gfn = cur_paddr >> xenctrl::PAGE_SHIFT;
             offset = ((xenctrl::PAGE_SIZE - 1) as u64) & cur_paddr;
             // map gfn
-            let page = self.xen_fgn.map(self.domid, PROT_READ, gfn).unwrap();
+            let page = self.xen_fgn.map(self.domid, PROT_READ, gfn)?;
             // determine how much we can read
             if (offset + count_mut as u64) > xenctrl::PAGE_SIZE as u64 {
                 read_len = (xenctrl::PAGE_SIZE as u64) - offset;


### PR DESCRIPTION
Add incomplete implementation of `read_physical` API

uses `map`/`unmap` pages in `xenforeignmemory`:
https://github.com/Wenzel/xenforeignmemory/blob/master/src/lib.rs#L25

