### PR TITLE
Add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: rust
+rust:
+  - stable
+
+sudo: required
+matrix:
+  include:
+    - name: "Dummy"
+      script:
+        - cargo build
+
+    - name: "Xen"
+      install:
+        - sudo apt-get install libxen-dev
+      script:
+        - cargo build --features xen

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-dist: xenial
+dist: bionic
 
 sudo: required
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - stable
+dist: xenial
 
 sudo: required
 matrix:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # libmicrovmi
 
+[![Build Status](https://travis-ci.com/Wenzel/libmicrovmi.svg?branch=master)](https://travis-ci.com/Wenzel/libmicrovmi)
 [![Join the chat at https://gitter.im/libmicrovmi/community](https://badges.gitter.im/libmicrovmi/community.svg)](https://gitter.im/libmicrovmi/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 


### PR DESCRIPTION
Add travis build to test Dummy and Xen driver build.

Currently the Xen driver doesn't build because it depends on `xenforeignmemory` crate, which depends on `/usr/include/xenforeignmemory.h`.

This header doesn't exist on `Ubuntu Xenial libxen-dev`, too recent.
