### PR TITLE
Error handling

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 pub enum DriverType {
     Dummy,
     #[cfg(feature="xen")]
@@ -8,14 +10,14 @@ pub enum DriverType {
 
 pub trait Introspectable {
     // read physical memory
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),&str>;
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<Error>>;
 
     // get max physical address
-    fn get_max_physical_addr(&self) -> Result<u64,&str>;
+    fn get_max_physical_addr(&self) -> Result<u64,Box<Error>>;
 
     // pause the VM
-    fn pause(&mut self);
+    fn pause(&mut self) -> Result<(),Box<Error>>;
 
     // resume the VM
-    fn resume(&mut self);
+    fn resume(&mut self) -> Result<(),Box<Error>>;
 }

--- a/src/bin/mem-dump.rs
+++ b/src/bin/mem-dump.rs
@@ -21,11 +21,11 @@ fn main() {
     let dump_path = Path::new(&dump_name);
     let mut dump_file = File::create(dump_path).expect("Fail to open dump file");
 
-    let drv_type = DriverType::KVM;
+    let drv_type = DriverType::Dummy;
     let mut drv: Box<Introspectable> = microvmi::init(drv_type, domain_name);
 
     println!("pausing the VM");
-    drv.pause();
+    drv.pause().expect("Failed to pause VM");
 
     let mut buffer: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
     let max_addr = drv.get_max_physical_addr().unwrap();
@@ -43,5 +43,5 @@ fn main() {
     }
 
     println!("resuming the VM");
-    drv.resume();
+    drv.resume().expect("Failed to resume VM");
 }

--- a/src/driver/dummy.rs
+++ b/src/driver/dummy.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use crate::api;
 
 // unit struct
@@ -13,21 +14,23 @@ impl Dummy {
 }
 
 impl api::Introspectable for Dummy {
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),&str> {
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<Error>> {
         println!("dummy read physical - @{}, {:#?}", paddr, buf);
         Ok(())
     }
 
-    fn get_max_physical_addr(&self) -> Result<u64,&str> {
+    fn get_max_physical_addr(&self) -> Result<u64,Box<Error>> {
         println!("dummy get max physical address");
         Ok(0)
     }
 
-    fn pause(&mut self) {
+    fn pause(&mut self) -> Result<(),Box<Error>> {
         println!("dummy pause");
+        Ok(())
     }
 
-    fn resume(&mut self) {
+    fn resume(&mut self) -> Result<(),Box<Error>> {
         println!("dummy resume");
+        Ok(())
     }
 }

--- a/src/driver/kvm.rs
+++ b/src/driver/kvm.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use crate::api;
 use kvmi::{KVMi, KVMiEventType};
 
@@ -27,33 +28,30 @@ impl Kvm {
 
 impl api::Introspectable for Kvm {
 
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),&str> {
-        match self.kvmi.read_physical(paddr, buf) {
-            Err(_) => Err("Failed to read physical memory"),
-            Ok(_) => Ok(()),
-        }
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<Error>> {
+        Ok(self.kvmi.read_physical(paddr, buf)?)
     }
 
-    fn get_max_physical_addr(&self) -> Result<u64,&str> {
+    fn get_max_physical_addr(&self) -> Result<u64,Box<Error>> {
         // No API in KVMi at the moment
         // fake 512MB
         let max_addr = 1024 * 1024 * 512;
         Ok(max_addr)
     }
 
-    fn pause(&mut self) {
+    fn pause(&mut self) -> Result<(),Box<Error>> {
         println!("KVM driver pause");
         // already paused ?
         if self.expect_pause_ev > 0 {
             ()
         }
 
-        self.expect_pause_ev = self.kvmi.pause()
-            .expect("Failed to pause KVM VCPUs");
+        self.expect_pause_ev = self.kvmi.pause()?;
         println!("expected pause events: {}", self.expect_pause_ev);
+        Ok(())
     }
 
-    fn resume(&mut self) {
+    fn resume(&mut self) -> Result<(),Box<Error>> {
         println!("KVM driver resume");
         // already resumed ?
         if self.expect_pause_ev == 0{
@@ -62,21 +60,19 @@ impl api::Introspectable for Kvm {
 
         while self.expect_pause_ev > 0 {
             // wait
-            self.kvmi.wait_event(1000)
-                .expect("Failed to wait for next KVMi event");
+            self.kvmi.wait_event(1000)?;
             // pop
-            let kvmi_event = self.kvmi.pop_event()
-                .expect("Failed to pop KVMi event");
+            let kvmi_event = self.kvmi.pop_event()?;
             match kvmi_event.kind {
                 KVMiEventType::PauseVCPU => {
                     println!("Received Pause Event");
                     self.expect_pause_ev -= 1;
-                    self.kvmi.reply_continue(&kvmi_event)
-                        .expect("Failed to send reply");
+                    self.kvmi.reply_continue(&kvmi_event)?;
                 }
                 _ => panic!("Unexpected {:?} event type while resuming VM", kvmi_event.kind),
             }
         }
+        Ok(())
     }
 
 }

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use crate::api;
 use xenctrl::XenControl;
 use xenctrl::consts::{PAGE_SHIFT, PAGE_SIZE};
@@ -52,7 +53,7 @@ impl Xen {
 
 impl api::Introspectable for Xen {
 
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),&str> {
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<Error>> {
         let mut cur_paddr: u64;
         let mut offset: u64 = 0;
         let mut count_mut: u64 = buf.len() as u64;
@@ -83,19 +84,19 @@ impl api::Introspectable for Xen {
         Ok(())
     }
 
-    fn get_max_physical_addr(&self) -> Result<u64,&str> {
-        let max_gpfn = self.xc.domain_maximum_gpfn(self.domid).unwrap();
+    fn get_max_physical_addr(&self) -> Result<u64,Box<Error>> {
+        let max_gpfn = self.xc.domain_maximum_gpfn(self.domid)?;
         Ok(max_gpfn << PAGE_SHIFT)
     }
 
-    fn pause(&self) {
+    fn pause(&mut self) -> Result<(),Box<Error>> {
         println!("Xen driver pause");
-        self.xc.domain_pause(self.domid).unwrap();
+        Ok(self.xc.domain_pause(self.domid)?)
     }
 
-    fn resume(&self) {
+    fn resume(&mut self) -> Result<(),Box<Error>> {
         println!("Xen driver resume");
-        self.xc.domain_unpause(self.domid).unwrap();
+        Ok(self.xc.domain_unpause(self.domid)?)
     }
 
 }


### PR DESCRIPTION
I got rid of these hideous `Result<xxx,&str>` that i created at the beginning to use `Box<std::error::Error>`, which should give generic error handling in the trait's functions signatures.