### PR TITLE
deprecate bare traits, use dyn keyword

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -10,14 +10,14 @@ pub enum DriverType {
 
 pub trait Introspectable {
     // read physical memory
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<Error>>;
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<dyn Error>>;
 
     // get max physical address
-    fn get_max_physical_addr(&self) -> Result<u64,Box<Error>>;
+    fn get_max_physical_addr(&self) -> Result<u64,Box<dyn Error>>;
 
     // pause the VM
-    fn pause(&mut self) -> Result<(),Box<Error>>;
+    fn pause(&mut self) -> Result<(),Box<dyn Error>>;
 
     // resume the VM
-    fn resume(&mut self) -> Result<(),Box<Error>>;
+    fn resume(&mut self) -> Result<(),Box<dyn Error>>;
 }

--- a/src/bin/mem-dump.rs
+++ b/src/bin/mem-dump.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut dump_file = File::create(dump_path).expect("Fail to open dump file");
 
     let drv_type = DriverType::Dummy;
-    let mut drv: Box<Introspectable> = microvmi::init(drv_type, domain_name);
+    let mut drv: Box<dyn Introspectable> = microvmi::init(drv_type, domain_name);
 
     println!("pausing the VM");
     drv.pause().expect("Failed to pause VM");

--- a/src/driver/dummy.rs
+++ b/src/driver/dummy.rs
@@ -14,22 +14,22 @@ impl Dummy {
 }
 
 impl api::Introspectable for Dummy {
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<Error>> {
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<dyn Error>> {
         println!("dummy read physical - @{}, {:#?}", paddr, buf);
         Ok(())
     }
 
-    fn get_max_physical_addr(&self) -> Result<u64,Box<Error>> {
+    fn get_max_physical_addr(&self) -> Result<u64,Box<dyn Error>> {
         println!("dummy get max physical address");
         Ok(0)
     }
 
-    fn pause(&mut self) -> Result<(),Box<Error>> {
+    fn pause(&mut self) -> Result<(),Box<dyn Error>> {
         println!("dummy pause");
         Ok(())
     }
 
-    fn resume(&mut self) -> Result<(),Box<Error>> {
+    fn resume(&mut self) -> Result<(),Box<dyn Error>> {
         println!("dummy resume");
         Ok(())
     }

--- a/src/driver/kvm.rs
+++ b/src/driver/kvm.rs
@@ -28,18 +28,18 @@ impl Kvm {
 
 impl api::Introspectable for Kvm {
 
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<Error>> {
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<dyn Error>> {
         Ok(self.kvmi.read_physical(paddr, buf)?)
     }
 
-    fn get_max_physical_addr(&self) -> Result<u64,Box<Error>> {
+    fn get_max_physical_addr(&self) -> Result<u64,Box<dyn Error>> {
         // No API in KVMi at the moment
         // fake 512MB
         let max_addr = 1024 * 1024 * 512;
         Ok(max_addr)
     }
 
-    fn pause(&mut self) -> Result<(),Box<Error>> {
+    fn pause(&mut self) -> Result<(),Box<dyn Error>> {
         println!("KVM driver pause");
         // already paused ?
         if self.expect_pause_ev > 0 {
@@ -52,7 +52,7 @@ impl api::Introspectable for Kvm {
         Ok(())
     }
 
-    fn resume(&mut self) -> Result<(),Box<Error>> {
+    fn resume(&mut self) -> Result<(),Box<dyn Error>> {
         println!("KVM driver resume");
         // already resumed ?
         if self.expect_pause_ev == 0{

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -53,7 +53,7 @@ impl Xen {
 
 impl api::Introspectable for Xen {
 
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<Error>> {
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(),Box<dyn Error>> {
         let mut cur_paddr: u64;
         let mut offset: u64 = 0;
         let mut count_mut: u64 = buf.len() as u64;
@@ -84,17 +84,17 @@ impl api::Introspectable for Xen {
         Ok(())
     }
 
-    fn get_max_physical_addr(&self) -> Result<u64,Box<Error>> {
+    fn get_max_physical_addr(&self) -> Result<u64,Box<dyn Error>> {
         let max_gpfn = self.xc.domain_maximum_gpfn(self.domid)?;
         Ok(max_gpfn << PAGE_SHIFT)
     }
 
-    fn pause(&mut self) -> Result<(),Box<Error>> {
+    fn pause(&mut self) -> Result<(),Box<dyn Error>> {
         println!("Xen driver pause");
         Ok(self.xc.domain_pause(self.domid)?)
     }
 
-    fn resume(&mut self) -> Result<(),Box<Error>> {
+    fn resume(&mut self) -> Result<(),Box<dyn Error>> {
         println!("Xen driver resume");
         Ok(self.xc.domain_unpause(self.domid)?)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,20 +9,20 @@ use driver::xen::Xen;
 #[cfg(feature="kvm")]
 use driver::kvm::Kvm;
 
-pub fn init(driver_type: DriverType, domain_name: &String) -> Box<Introspectable> {
+pub fn init(driver_type: DriverType, domain_name: &String) -> Box<dyn Introspectable> {
     println!("vmi init");
 
     match driver_type {
         DriverType::Dummy => {
-            Box::new(Dummy::new(domain_name)) as Box<Introspectable>
+            Box::new(Dummy::new(domain_name)) as Box<dyn Introspectable>
         },
         #[cfg(feature="xen")]
         DriverType::Xen => {
-            Box::new(Xen::new(domain_name)) as Box<Introspectable>
+            Box::new(Xen::new(domain_name)) as Box<dyn Introspectable>
         },
         #[cfg(feature="kvm")]
         DriverType::KVM => {
-            Box::new(Kvm::new(domain_name)) as Box<Introspectable>
+            Box::new(Kvm::new(domain_name)) as Box<dyn Introspectable>
         },
     }
 }


### PR DESCRIPTION
rust 1.38.0 deprecates bare traits