### PR TITLE
WIP: Xen events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "lib"]
 
 [features]
 # Xen driver
-xen = ["xenctrl", "xenstore", "xenforeignmemory", "xenevtchn", "libc"]
+xen = ["xenctrl", "xenstore", "xenforeignmemory", "xenevtchn", "xenvmevent-sys", "libc"]
 # KVM driver
 kvm = ["kvmi"]
 # VirtualBox driver
@@ -25,6 +25,7 @@ xenctrl = { git = "https://github.com/Wenzel/xenctrl", optional = true }
 xenstore = { git = "https://github.com/Wenzel/xenstore", optional = true }
 xenforeignmemory = { git = "https://github.com/Wenzel/xenforeignmemory", optional = true }
 xenevtchn = { git = "https://github.com/Wenzel/xenevtchn", optional = true }
+xenvmevent-sys = { git = "https://github.com/Wenzel/xenvmevent-sys", optional = true }
 kvmi = { git = "https://github.com/Wenzel/kvmi.git", optional = true }
 fdp = { git = "https://github.com/Wenzel/fdp", optional = true }
 winapi = { version = "0.3.8", features = ["tlhelp32", "winnt", "handleapi", "securitybaseapi"], optional = true }
@@ -34,11 +35,3 @@ vid-sys = { version = "0.3.0", features = ["deprecated-apis"], optional = true }
 
 [dev-dependencies]
 env_logger = "0.7.1"
-
-# [patch.crates-io]
-# vid-sys = { path = "../vid-sys" }
-
-# [patch.'https://github.com/Wenzel/xenctrl']
-# xenctrl = { path = '../xenctrl', optional = true }
-# [patch.'https://github.com/Wenzel/xenevtchn']
-# xenevtchn = { path = '../xenevtchn', optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "lib"]
 
 [features]
 # Xen driver
-xen = ["xenctrl", "xenstore", "xenforeignmemory", "libc"]
+xen = ["xenctrl", "xenstore", "xenforeignmemory", "xenevtchn", "libc"]
 # KVM driver
 kvm = ["kvmi"]
 # VirtualBox driver
@@ -24,6 +24,7 @@ libc = { version = "0.2.58", optional = true }
 xenctrl = { git = "https://github.com/Wenzel/xenctrl", optional = true }
 xenstore = { git = "https://github.com/Wenzel/xenstore", optional = true }
 xenforeignmemory = { git = "https://github.com/Wenzel/xenforeignmemory", optional = true }
+xenevtchn = { git = "https://github.com/Wenzel/xenevtchn", optional = true }
 kvmi = { git = "https://github.com/Wenzel/kvmi.git", optional = true }
 fdp = { git = "https://github.com/Wenzel/fdp", optional = true }
 winapi = { version = "0.3.8", features = ["tlhelp32", "winnt", "handleapi", "securitybaseapi"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,8 @@ env_logger = "0.7.1"
 
 # [patch.crates-io]
 # vid-sys = { path = "../vid-sys" }
+
+# [patch.'https://github.com/Wenzel/xenctrl']
+# xenctrl = { path = '../xenctrl', optional = true }
+# [patch.'https://github.com/Wenzel/xenevtchn']
+# xenevtchn = { path = '../xenevtchn', optional = true }

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -3,7 +3,7 @@ use libc::PROT_READ;
 use std::error::Error;
 use xenctrl::consts::{PAGE_SHIFT, PAGE_SIZE};
 use xenctrl::XenControl;
-//use xenevtchn::XenEventChannel;
+use xenevtchn::XenEventChannel;
 use xenforeignmemory::XenForeignMem;
 use xenstore::{Xs, XBTransaction, XsOpenFlags};
 
@@ -42,7 +42,10 @@ impl Xen {
 //        let ring_page = unsafe {
 //
 //        };
-//        let xev = XenEventChannel::new(cand_domid, remote_port);
+        let xev = XenEventChannel::new(cand_domid, remote_port);
+        // init shared and back rings
+        // SHARED_RING_INIT(ring_page);
+        // BACK_RING_INIT(& back_ring, ring_page, XC_PAGE_SIZE);
         let xen_fgn = XenForeignMem::new().unwrap();
         let xen = Xen {
             xc,


### PR DESCRIPTION
This PR initializes Xen events system.

It's not ready yet.
Current status is that I can't initialize the `ring_page`, since it requires a C macro that is dynamically created.

In C, we could have done the following;
~~~C
// map ring buffer via xc_monitor_enable
uint32_t remote_port;
// returns the address of the shared ring buffer in Dom0
// also provides a remote port associated with the guest
vm_event_sring_t* ring_page = (vm_event_sring_t*) xc_monitor_enable(xenctrl_handle, domid, &remote_port);
// pass the remote port to xenevtchn_bind_interdomain
uint32_t local_port = xenevtchn_bind_interdomain(xenevtchn_handle, domid, remote_port);

// init the ring
vm_event_back_ring_t back_ring;
SHARED_RING_INIT(ring_page);
BACK_RING_INIT(& back_ring, ring_page, XC_PAGE_SIZE);
~~~

The `// init the ring` part is problematic, because it relies on Macros, defined in [`xen/io/ring.h`](https://github.com/xen-project/xen/blob/RELEASE-4.12.0/xen/include/public/io/ring.h#L171)

And bindgen cannot provide these Macros.
Worse thing is that the `structs` like `vm_event_sring_t*` are dynamically defined in the Macros too:
https://github.com/xen-project/xen/blob/RELEASE-4.12.0/xen/include/public/io/ring.h#L118

ping @tathanhdinh about bindgen and C ffi bindings, if you have an idea ?

Some documentation on Xen VMI API. (thanks @smichaels-ncc !! :+1: )
https://static.sched.com/hosted_files/xensummit19/32/Spencer%20Michaels%20-%20Xen%20API%20Archaeology%20-%20Creating%20A%20Full-Featured%20VMI%20Debugger%20For%20The%20Xen%20Hypervisor.pdf