### PR TITLE
actions: trigger build on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [pull_request]
 
 jobs:
   dummy:


### PR DESCRIPTION
This should fix https://github.com/Wenzel/libmicrovmi/pull/52 not triggering a CI build.

