### PR TITLE
Clap cr events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,4 @@ cty = "0.2.1"
 env_logger = "0.7.1"
 ctrlc = "3.1.3"
 clap = "2.33.0"
-
+colored = "1.9.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,5 @@ cty = "0.2.1"
 [dev-dependencies]
 env_logger = "0.7.1"
 ctrlc = "3.1.3"
+clap = "2.33.0"
 
-# [patch.crates-io]
-# vid-sys = { path = "../vid-sys" }

--- a/examples/cr-events.rs
+++ b/examples/cr-events.rs
@@ -52,6 +52,7 @@ fn main() {
     })
     .expect("Error setting Ctrl-C handler");
 
+    println!("Initialize Libmicrovmi");
     let mut drv: Box<dyn Introspectable> = microvmi::init(domain_name, None);
 
     drv.pause().expect("Failed to pause VM");

--- a/examples/cr-events.rs
+++ b/examples/cr-events.rs
@@ -98,7 +98,7 @@ fn main() {
     // disable control register interception
     for cr in &vec_cr {
         let intercept = InterceptType::Cr(*cr);
-        println!("Disbaling intercept of {:?}", cr);
+        println!("Disabling intercept of {:?}", cr);
         for vcpu in 0..drv.get_vcpu_count().unwrap() {
             drv.toggle_intercept(vcpu, intercept, false)
                 .expect("Failed to disable control register interception");

--- a/examples/cr-events.rs
+++ b/examples/cr-events.rs
@@ -10,7 +10,7 @@ use microvmi::api::{CrType, EventReplyType, EventType, InterceptType, Introspect
 fn main() {
     env_logger::init();
 
-    let matches = App::new("Control Register Events")
+    let matches = App::new(file!())
         .version("0.2")
         .author("Mathieu Tarral")
         .about("Watches control register VMI events")

--- a/examples/cr-events.rs
+++ b/examples/cr-events.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use clap::{App, Arg};
+use colored::*;
 use env_logger;
 
 use microvmi::api::{CrType, EventReplyType, EventType, InterceptType, Introspectable};
@@ -83,7 +84,19 @@ fn main() {
                         old: _,
                     } => (cr_type, new),
                 };
-                println!("[{}] VCPU {} - {:?}: 0x{:x}", i, ev.vcpu, cr_type, new);
+                let cr_color = match cr_type {
+                    CrType::Cr0 => "blue",
+                    CrType::Cr3 => "green",
+                    CrType::Cr4 => "red",
+                };
+                let ev_nb_output = format!("{}", i).cyan();
+                let vcpu_output = format!("VCPU {}", ev.vcpu).yellow();
+                let cr_output = format!("{:?}", cr_type).color(cr_color);
+                // let output = format!("[{}] VCPU {} - {:?}: 0x{:x}", i, ev.vcpu, cr_type, new);
+                println!(
+                    "[{}] {} - {}: 0x{:x}",
+                    ev_nb_output, vcpu_output, cr_output, new
+                );
                 drv.reply_event(ev, EventReplyType::Continue)
                     .expect("Failed to send event reply");
                 i = i + 1;

--- a/examples/cr-events.rs
+++ b/examples/cr-events.rs
@@ -71,7 +71,7 @@ fn main() {
     // record elapsed time
     let start = Instant::now();
     // listen
-    let mut i: u64 = 1;
+    let mut i: u64 = 0;
     while running.load(Ordering::SeqCst) {
         let event = drv.listen(1000).expect("Failed to listen for events");
         match event {
@@ -86,10 +86,10 @@ fn main() {
                 println!("[{}] VCPU {} - {:?}: 0x{:x}", i, ev.vcpu, cr_type, new);
                 drv.reply_event(ev, EventReplyType::Continue)
                     .expect("Failed to send event reply");
+                i = i + 1;
             }
             None => println!("No events yet..."),
         }
-        i = i + 1;
     }
     let duration = start.elapsed();
 

--- a/examples/cr3-events.rs
+++ b/examples/cr3-events.rs
@@ -4,18 +4,25 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use env_logger;
+use clap::{Arg, App, SubCommand};
 
 use microvmi::api::{CrType, EventReplyType, EventType, InterceptType, Introspectable};
 
 fn main() {
     env_logger::init();
 
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
-        println!("Usage: {} <vm_name>", args[0]);
-        return;
-    }
-    let domain_name = &args[1];
+    let matches = App::new("Control Register Events")
+        .version("0.2")
+        .author("Mathieu Tarral")
+        .about("Watches control register VMI events")
+        .arg(
+            Arg::with_name("vm_name")
+                .index(1)
+                .required(true)
+        )
+        .get_matches();
+
+    let domain_name = matches.value_of("vm_name").unwrap();
 
     // set CTRL-C handler
     let running = Arc::new(AtomicBool::new(true));


### PR DESCRIPTION
@rageagainsthepc this PR adds `clap` command line to `cr-events` example, to pass multiple control registers to watch.
Default is CR3.