### PR TITLE
Driver init option

### DIFF
--- a/c_examples/mem-dump.c
+++ b/c_examples/mem-dump.c
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     microvmi_envlogger_init();
-    void* driver = microvmi_init(argv[1], NULL);
+    void* driver = microvmi_init(argv[1], NULL, NULL);
     dump_memory(driver, argv[1]);
     microvmi_destroy(driver);
     return 0;

--- a/c_examples/pause.c
+++ b/c_examples/pause.c
@@ -29,7 +29,7 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     microvmi_envlogger_init();
-    void* driver = microvmi_init(argv[1], NULL);
+    void* driver = microvmi_init(argv[1], NULL, NULL);
     pause_vm(driver, sleep_duration_sec * 1000000);
     microvmi_destroy(driver);
     return 0;

--- a/c_examples/regs-dump.c
+++ b/c_examples/regs-dump.c
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     microvmi_envlogger_init();
-    void* driver = microvmi_init(argv[1], NULL);
+    void* driver = microvmi_init(argv[1], NULL, NULL);
     read_registers(driver, argv[1]);
     microvmi_destroy(driver);
     return 0;

--- a/examples/regs-dump.rs
+++ b/examples/regs-dump.rs
@@ -1,21 +1,35 @@
-use std::env;
-extern crate env_logger;
-extern crate microvmi;
+use clap::{App, Arg, ArgMatches};
+use env_logger;
 
-// traits method can only be used if the trait is in the scope
-use microvmi::api::Introspectable;
+use microvmi::api::{DriverInitParam, Introspectable};
+
+fn parse_args() -> ArgMatches<'static> {
+    App::new(file!())
+        .version("0.1")
+        .author("Mathieu Tarral")
+        .about("Dumps the state of registers on VCPU 0")
+        .arg(Arg::with_name("vm_name").index(1).required(true))
+        .arg(
+            Arg::with_name("kvmi_socket")
+                .short("k")
+                .takes_value(true)
+                .help(
+                "pass additional KVMi socket initialization parameter required for the KVM driver",
+            ),
+        )
+        .get_matches()
+}
 
 fn main() {
     env_logger::init();
 
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
-        println!("Usage: {} <vm_name>", args[0]);
-        return;
-    }
-    let domain_name = &args[1];
+    let matches = parse_args();
+    let domain_name = matches.value_of("vm_name").unwrap();
 
-    let mut drv: Box<dyn Introspectable> = microvmi::init(domain_name, None);
+    let init_option = matches
+        .value_of("kvmi_socket")
+        .map(|socket| DriverInitParam::KVMiSocket(socket.into()));
+    let mut drv: Box<dyn Introspectable> = microvmi::init(domain_name, None, init_option);
 
     println!("pausing the VM");
     drv.pause().expect("Failed to pause VM");

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,8 @@
 use std::convert::TryInto;
 use std::error::Error;
 use std::ffi::{CStr, IntoStringError};
-use std::os::raw::c_char;
+
+use crate::capi::DriverInitParamFFI;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -43,14 +44,6 @@ impl TryInto<DriverInitParam> for DriverInitParamFFI {
             ),
         })
     }
-}
-
-/// Support passing initialization options
-/// similar to DriverInitParam, however this enum offers C API compatibility
-#[repr(C)]
-#[derive(Debug)]
-pub enum DriverInitParamFFI {
-    KVMiSocket(*const c_char),
 }
 
 #[repr(C)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,6 +14,20 @@ pub enum DriverType {
     Xen,
 }
 
+/// Supports passing initialization parameters to the driver
+///
+/// Some drivers can support optional extra initialization parameters.
+///
+/// This is required to initialize the KVM driver, which needs a `domain_name` and
+/// a `kvm_socket` parameters.
+///
+/// This is equivalent to LibVMI's `vmi_init_data_type_t`
+#[repr(C)]
+#[derive(Debug)]
+pub enum DriverInitParam {
+    KVMiSocket(String),
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct SegmentReg {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::convert::TryInto;
 use std::error::Error;
 use std::ffi::{CStr, IntoStringError};
 use std::os::raw::c_char;
@@ -31,11 +31,11 @@ pub enum DriverInitParam {
     KVMiSocket(String),
 }
 
-impl TryFrom<DriverInitParamFFI> for DriverInitParam {
+impl TryInto<DriverInitParam> for DriverInitParamFFI {
     type Error = IntoStringError;
 
-    fn try_from(param: DriverInitParamFFI) -> Result<Self, Self::Error> {
-        Ok(match param {
+    fn try_into(self) -> Result<DriverInitParam, Self::Error> {
+        Ok(match self {
             DriverInitParamFFI::KVMiSocket(cstr_socket) => DriverInitParam::KVMiSocket(
                 unsafe { CStr::from_ptr(cstr_socket) }
                     .to_owned()

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,4 +1,4 @@
-use crate::api::{DriverInitParam, DriverInitParamFFI, DriverType, Introspectable, Registers};
+use crate::api::{DriverInitParam, DriverType, Introspectable, Registers};
 use crate::init;
 use cty::{c_char, size_t, uint16_t, uint64_t, uint8_t};
 use std::convert::TryInto;
@@ -9,6 +9,14 @@ use std::slice;
 pub enum MicrovmiStatus {
     MicrovmiSuccess,
     MicrovmiFailure,
+}
+
+/// Support passing initialization options
+/// similar to DriverInitParam, however this enum offers C API compatibility
+#[repr(C)]
+#[derive(Debug)]
+pub enum DriverInitParamFFI {
+    KVMiSocket(*const c_char),
 }
 
 /// This API allows a C program to initialize the logging system in libmicrovmi.

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,7 +1,7 @@
 use crate::api::{DriverInitParam, DriverInitParamFFI, DriverType, Introspectable, Registers};
 use crate::init;
 use cty::{c_char, size_t, uint16_t, uint64_t, uint8_t};
-use std::convert::TryFrom;
+use std::convert::TryInto;
 use std::ffi::{c_void, CStr};
 use std::slice;
 
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn microvmi_init(
         None
     } else {
         Some(
-            DriverInitParam::try_from(driver_init_option.read())
+            DriverInitParamFFI::try_into(driver_init_option.read())
                 .expect("Failed to convert DriverInitParam C struct to Rust equivalent"),
         )
     };

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -32,7 +32,8 @@ pub unsafe extern "C" fn microvmi_init(
     } else {
         Some(driver_type.read())
     };
-    let driver = init(&safe_domain_name, optional_driver_type);
+    // TODO support passing driver init param
+    let driver = init(&safe_domain_name, optional_driver_type, None);
     Box::into_raw(Box::new(driver)) as *mut c_void
 }
 

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,4 +1,4 @@
-use crate::api::{DriverType, Introspectable, Registers};
+use crate::api::{DriverInitParam, DriverType, Introspectable, Registers};
 use crate::init;
 use cty::{c_char, size_t, uint16_t, uint64_t, uint8_t};
 use std::ffi::{c_void, CStr};
@@ -25,6 +25,7 @@ pub unsafe extern "C" fn microvmi_envlogger_init() {
 pub unsafe extern "C" fn microvmi_init(
     domain_name: *const c_char,
     driver_type: *const DriverType,
+    driver_init_option: *const DriverInitParam,
 ) -> *mut c_void {
     let safe_domain_name = CStr::from_ptr(domain_name).to_string_lossy().into_owned();
     let optional_driver_type: Option<DriverType> = if driver_type.is_null() {
@@ -32,8 +33,12 @@ pub unsafe extern "C" fn microvmi_init(
     } else {
         Some(driver_type.read())
     };
-    // TODO support passing driver init param
-    let driver = init(&safe_domain_name, optional_driver_type, None);
+    let init_option: Option<DriverInitParam> = if driver_init_option.is_null() {
+        None
+    } else {
+        Some(driver_init_option.read())
+    };
+    let driver = init(&safe_domain_name, optional_driver_type, init_option);
     Box::into_raw(Box::new(driver)) as *mut c_void
 }
 

--- a/src/driver/dummy.rs
+++ b/src/driver/dummy.rs
@@ -1,11 +1,11 @@
-use crate::api::Introspectable;
+use crate::api::{DriverInitParam, Introspectable};
 use std::error::Error;
 
 // unit struct
 pub struct Dummy;
 
 impl Dummy {
-    pub fn new(domain_name: &str) -> Self {
+    pub fn new(domain_name: &str, _init_option: Option<DriverInitParam>) -> Self {
         debug!("init on {}", domain_name);
         Dummy
     }

--- a/src/driver/hyperv.rs
+++ b/src/driver/hyperv.rs
@@ -6,7 +6,7 @@ use std::ptr::{null, null_mut};
 use std::slice;
 use std::vec::Vec;
 
-use crate::api::Introspectable;
+use crate::api::{DriverInitParam, Introspectable};
 
 use ntapi::ntexapi::{
     NtQuerySystemInformation, SystemHandleInformation, SYSTEM_HANDLE_INFORMATION,
@@ -159,7 +159,7 @@ pub struct HyperV {
 }
 
 impl HyperV {
-    pub fn new(domain_name: &str) -> Self {
+    pub fn new(domain_name: &str, _init_option: Option<DriverInitParam>) -> Self {
         debug!("HyperV driver init on {}", domain_name);
 
         Self::enable_se_debug_privilege();

--- a/src/driver/virtualbox.rs
+++ b/src/driver/virtualbox.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use fdp::FDP;
 
-use crate::api::Introspectable;
+use crate::api::{DriverInitParam, Introspectable};
 
 // unit struct
 #[derive(Debug)]
@@ -11,7 +11,7 @@ pub struct VBox {
 }
 
 impl VBox {
-    pub fn new(domain_name: &str) -> Self {
+    pub fn new(domain_name: &str, _init_option: Option<DriverInitParam>) -> Self {
         // init FDP
         let fdp = FDP::new(domain_name);
         VBox { fdp }

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -1,4 +1,4 @@
-use crate::api::{Introspectable, Registers, SegmentReg, X86Registers};
+use crate::api::{DriverInitParam, Introspectable, Registers, SegmentReg, X86Registers};
 use libc::PROT_READ;
 use std::error::Error;
 use xenctrl::consts::{PAGE_SHIFT, PAGE_SIZE};
@@ -15,7 +15,7 @@ pub struct Xen {
 }
 
 impl Xen {
-    pub fn new(domain_name: &str) -> Self {
+    pub fn new(domain_name: &str, _init_option: Option<DriverInitParam>) -> Self {
         debug!("init on {}", domain_name);
         // find domain name in xenstore
         let xs = Xs::new(XsOpenFlags::ReadOnly).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@ mod driver;
 #[macro_use]
 extern crate log;
 
-use api::DriverType;
 use api::Introspectable;
+use api::{DriverInitParam, DriverType};
 use driver::dummy::Dummy;
 #[cfg(feature = "hyper-v")]
 use driver::hyperv::HyperV;
@@ -20,51 +20,63 @@ use driver::xen::Xen;
 use kvmi::create_kvmi;
 
 #[allow(unreachable_code)]
-pub fn init(domain_name: &str, driver_type: Option<DriverType>) -> Box<dyn Introspectable> {
+pub fn init(
+    domain_name: &str,
+    driver_type: Option<DriverType>,
+    init_option: Option<DriverInitParam>,
+) -> Box<dyn Introspectable> {
     debug!("Microvmi init");
     match driver_type {
         Some(drv_type) => match drv_type {
-            DriverType::Dummy => Box::new(Dummy::new(domain_name)) as Box<dyn Introspectable>,
+            DriverType::Dummy => {
+                Box::new(Dummy::new(domain_name, init_option)) as Box<dyn Introspectable>
+            }
             #[cfg(feature = "hyper-v")]
-            DriverType::HyperV => Box::new(HyperV::new(domain_name)) as Box<dyn Introspectable>,
+            DriverType::HyperV => {
+                Box::new(HyperV::new(domain_name, init_option)) as Box<dyn Introspectable>
+            }
             #[cfg(feature = "kvm")]
-            DriverType::KVM => create_kvm(domain_name),
+            DriverType::KVM => create_kvm(domain_name, init_option),
             #[cfg(feature = "virtualbox")]
-            DriverType::VirtualBox => Box::new(VBox::new(domain_name)) as Box<dyn Introspectable>,
+            DriverType::VirtualBox => {
+                Box::new(VBox::new(domain_name, init_option)) as Box<dyn Introspectable>
+            }
             #[cfg(feature = "xen")]
-            DriverType::Xen => Box::new(Xen::new(domain_name)) as Box<dyn Introspectable>,
+            DriverType::Xen => {
+                Box::new(Xen::new(domain_name, init_option)) as Box<dyn Introspectable>
+            }
         },
         None => {
             // test Hyper-V
             #[cfg(feature = "hyper-v")]
             {
-                return Box::new(HyperV::new(domain_name)) as Box<dyn Introspectable>;
+                return Box::new(HyperV::new(domain_name, init_option)) as Box<dyn Introspectable>;
             }
 
             // test KVM
             #[cfg(feature = "kvm")]
             {
-                return create_kvm(domain_name);
+                return create_kvm(domain_name, init_option);
             }
 
             // test VirtualBox
             #[cfg(feature = "virtualbox")]
             {
-                return Box::new(VBox::new(domain_name)) as Box<dyn Introspectable>;
+                return Box::new(VBox::new(domain_name, init_option)) as Box<dyn Introspectable>;
             }
 
             // test Xen
             #[cfg(feature = "xen")]
             {
-                return Box::new(Xen::new(domain_name)) as Box<dyn Introspectable>;
+                return Box::new(Xen::new(domain_name, init_option)) as Box<dyn Introspectable>;
             }
             // return Dummy if no other driver has been compiled
-            Box::new(Dummy::new(domain_name)) as Box<dyn Introspectable>
+            Box::new(Dummy::new(domain_name, init_option)) as Box<dyn Introspectable>
         }
     }
 }
 
 #[cfg(feature = "kvm")]
-fn create_kvm(domain_name: &str) -> Box<dyn Introspectable> {
-    Box::new(Kvm::new(domain_name, create_kvmi()).unwrap()) as Box<dyn Introspectable>
+fn create_kvm(domain_name: &str, init_option: Option<DriverInitParam>) -> Box<dyn Introspectable> {
+    Box::new(Kvm::new(domain_name, create_kvmi(), init_option).unwrap()) as Box<dyn Introspectable>
 }


### PR DESCRIPTION
This PR adds support for additional driver initialization parameters.

This is required for KVM driver, which needs a socket parameter.
Before that it was simply hardcoded to `/tmp/introspector` in the driver.

I added documentation for the new type `DriverInitParam`.
and I converted all examples to the `clap` argument parsing library, so it's easier to support command line parameters in the future.

Naming: what is better:

- `DriverInitParam`
- `DriverInitOption`
- other naming suggestions
:thinking: 