### PR TITLE
introduce kvm driver tests (wrapped kvmi)

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,8 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+output-type: lcov
+ignore:
+  - "/*"
+  - "C:/*"
+  - "../*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,11 @@ jobs:
           name: clippy kvm
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --features kvm -- -D warnings
+      - name: test KVM driver
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features kvm
 
 
   virtualbox:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,11 +78,42 @@ jobs:
           name: clippy kvm
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --features kvm -- -D warnings
+      - name: remove compilation artifacts from stable toolchain
+        uses: actions-rs/cargo@v1
+        with:
+          command: clean
+      - name: install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
       - name: test KVM driver
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features kvm
+          # The target arg is a workaround in order to prevent build.rs files from being compiled with RUSTFLAGS
+          # -Cpanic=abort can lead to issues with bindgen during compile time
+          args: --features kvm --no-fail-fast --target x86_64-unknown-linux-gnu
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+      - name: install grcov
+        uses: actions-rs/install@v0.1
+        with:
+          crate: grcov
+          version: latest
+          use-tool-cache: true
+      - name: generate coverage report
+        id: coverage
+        uses: actions-rs/grcov@v0.1
+      - name: upload coverage report to codecov.io
+        uses: codecov/codecov-action@v1
+        with:
+          file: ${{ steps.coverage.outputs.report }}
+          flags: unittests
+          fail_ci_if_error: true
 
 
   virtualbox:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,8 @@ env_logger = "0.7.1"
 ctrlc = "3.1.3"
 clap = "2.33.0"
 colored = "1.9.3"
+mockall = "0.7.1"
+test-case = "1.0.0"
+
+[patch."https://github.com/Wenzel/kvmi"]
+kvmi = { git = "https://github.com/rageagainsthepc/kvmi", branch = "testing-poc-wrapping" }


### PR DESCRIPTION
This would be the wrapping approach. I wanted to use automock which can't mock multiple traits so I had to remove `#[derive(Debug)]` from the Kvm struct. But I think it is better to use a debugger instead of println debugging anyway so no tears there.