### PR TITLE
add microvmi_envlogger_init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ hyper-v = ["winapi", "widestring", "ntapi", "vid-sys"]
 
 [dependencies]
 log = "0.4.8"
+env_logger = "0.7.1"
 libc = { version = "0.2.58", optional = true }
 xenctrl = { git = "https://github.com/Wenzel/xenctrl", optional = true }
 xenstore = { git = "https://github.com/Wenzel/xenstore", optional = true }
@@ -33,7 +34,6 @@ vid-sys = { version = "0.3.0", features = ["deprecated-apis"], optional = true }
 cty = "0.2.1"
 
 [dev-dependencies]
-env_logger = "0.7.1"
 ctrlc = "3.1.3"
 clap = "2.33.0"
 colored = "1.9.3"

--- a/c_examples/mem-dump.c
+++ b/c_examples/mem-dump.c
@@ -42,6 +42,7 @@ int main(int argc, char* argv[]) {
         printf("No domain name given.\n");
         return 1;
     }
+    microvmi_init_envlogger();
     void* driver = microvmi_init(argv[1], NULL);
     dump_memory(driver, argv[1]);
     microvmi_destroy(driver);

--- a/c_examples/pause.c
+++ b/c_examples/pause.c
@@ -28,6 +28,7 @@ int main(int argc, char* argv[]) {
         printf("Unable to parse sleep duration or zero provided.\n");
         return 1;
     }
+    microvmi_init_envlogger();
     void* driver = microvmi_init(argv[1], NULL);
     pause_vm(driver, sleep_duration_sec * 1000000);
     microvmi_destroy(driver);

--- a/c_examples/regs-dump.c
+++ b/c_examples/regs-dump.c
@@ -40,6 +40,7 @@ int main(int argc, char* argv[]) {
         printf("No domain name given.\n");
         return 1;
     }
+    microvmi_init_envlogger();
     void* driver = microvmi_init(argv[1], NULL);
     read_registers(driver, argv[1]);
     microvmi_destroy(driver);

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -10,6 +10,16 @@ pub enum MicrovmiStatus {
     MicrovmiFailure,
 }
 
+/// This API allows a C program to initialize the logging system in libmicrovmi.
+/// This simply calls env_logger::init()
+/// Usually, it's the library consumer who should add this Rust crate dependency,
+/// however, with a C program, we provide this workaround where we provide an API to do just that.
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn microvmi_envlogger_init() {
+    env_logger::init();
+}
+
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn microvmi_init(


### PR DESCRIPTION
fix #95 

This PR adds a new capi: `microvmi_envlogger_init`, to allow a C program to init the env_logger from C.

![Capture d’écran de 2020-08-10 21-24-15](https://user-images.githubusercontent.com/964610/89822969-f1ded280-db50-11ea-9f77-7f63df9e06f9.png)
