### PR TITLE
codecov: set drop threshold to 10%

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        # allow coverage to drop by this amount and still post success
+        threshold: 10


### PR DESCRIPTION
Thanks to this PR, i found how to fix our codecov CI error:
https://github.com/ros-planning/moveit/pull/1917