### PR TITLE
System Table registers (IDTR/GDTR)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -72,6 +72,17 @@ pub struct SegmentReg {
     pub selector: u16,
 }
 
+/// x86 System Table Registers
+/// (GDTR, IDTR)
+#[repr(C)]
+#[derive(Debug)]
+pub struct SystemTableReg {
+    /// 32/64 bits linear base address
+    pub base: u64,
+    /// 16 bits table limit
+    pub limit: u16,
+}
+
 ///Represents all x86 registers on a specific VCPU
 #[repr(C)]
 #[derive(Debug)]
@@ -152,6 +163,8 @@ pub struct X86Registers {
     pub tr: SegmentReg,
     /// Local descriptor table register
     pub ldt: SegmentReg,
+    pub idt: SystemTableReg,
+    pub gdt: SystemTableReg,
 }
 
 #[repr(C)]

--- a/src/driver/kvm.rs
+++ b/src/driver/kvm.rs
@@ -11,7 +11,7 @@ use std::vec::Vec;
 
 use crate::api::{
     Access, CrType, DriverInitParam, Event, EventReplyType, EventType, InterceptType,
-    Introspectable, Registers, SegmentReg, X86Registers, PAGE_SHIFT,
+    Introspectable, Registers, SegmentReg, SystemTableReg, X86Registers, PAGE_SHIFT,
 };
 
 impl TryFrom<Access> for KVMiPageAccess {
@@ -192,6 +192,14 @@ impl<T: KVMIntrospectable> Introspectable for Kvm<T> {
             ss: sregs.ss.into(),
             tr: sregs.tr.into(),
             ldt: sregs.ldt.into(),
+            idt: SystemTableReg {
+                base: sregs.idt.base,
+                limit: sregs.idt.limit,
+            },
+            gdt: SystemTableReg {
+                base: sregs.gdt.base,
+                limit: sregs.idt.limit,
+            },
         }))
     }
 

--- a/src/driver/kvm.rs
+++ b/src/driver/kvm.rs
@@ -1,6 +1,6 @@
 use kvmi::{
-    kvm_regs, kvm_segment, KVMIntrospectable, KVMiCr, KVMiEvent, KVMiEventReply, KVMiEventType,
-    KVMiInterceptType, KVMiPageAccess,
+    kvm_dtable, kvm_regs, kvm_segment, KVMIntrospectable, KVMiCr, KVMiEvent, KVMiEventReply,
+    KVMiEventType, KVMiInterceptType, KVMiPageAccess,
 };
 use std::convert::From;
 use std::convert::TryFrom;
@@ -52,6 +52,15 @@ impl From<kvm_segment> for SegmentReg {
             base: segment.base,
             limit: segment.limit,
             selector: segment.selector,
+        }
+    }
+}
+
+impl From<kvm_dtable> for SystemTableReg {
+    fn from(dtable: kvm_dtable) -> Self {
+        SystemTableReg {
+            base: dtable.base,
+            limit: dtable.limit,
         }
     }
 }
@@ -192,14 +201,8 @@ impl<T: KVMIntrospectable> Introspectable for Kvm<T> {
             ss: sregs.ss.into(),
             tr: sregs.tr.into(),
             ldt: sregs.ldt.into(),
-            idt: SystemTableReg {
-                base: sregs.idt.base,
-                limit: sregs.idt.limit,
-            },
-            gdt: SystemTableReg {
-                base: sregs.gdt.base,
-                limit: sregs.idt.limit,
-            },
+            idt: sregs.idt.into(),
+            gdt: sregs.gdt.into(),
         }))
     }
 

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -1,4 +1,6 @@
-use crate::api::{DriverInitParam, Introspectable, Registers, SegmentReg, X86Registers};
+use crate::api::{
+    DriverInitParam, Introspectable, Registers, SegmentReg, SystemTableReg, X86Registers,
+};
 use libc::PROT_READ;
 use std::error::Error;
 use xenctrl::consts::{PAGE_SHIFT, PAGE_SIZE};
@@ -160,6 +162,14 @@ impl Introspectable for Xen {
                 base: 0,
                 limit: 0,
                 selector: 0,
+            },
+            idt: SystemTableReg {
+                base: hvm_cpu.idtr_base,
+                limit: hvm_cpu.idtr_limit as u16,
+            },
+            gdt: SystemTableReg {
+                base: hvm_cpu.gdtr_base,
+                limit: hvm_cpu.gdtr_limit as u16,
             },
         }))
     }


### PR DESCRIPTION
help fix #111 in Xen

- add definition of IDTR/GDTR (https://xem.github.io/minix86/manual/intel-x86-and-64-manual-vol3/o_fe12b1e2a880e0ce-74.html)
- fetch them in Xen
- fetch them in KVM

regs-dump example (with a little tweak to force get_vcpu_count to 1)
![Capture d’écran de 2020-08-18 01-16-31](https://user-images.githubusercontent.com/964610/90453300-8ff21000-e0f0-11ea-9a2a-fbc5842bf752.png)
