### PR TITLE
xen: handle permission denied when reading xenstore entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [features]
 # Xen driver
-xen = ["xenctrl", "xenstore", "xenforeignmemory", "libc"]
+xen = ["xenctrl", "xenstore-rs", "xenforeignmemory", "libc"]
 # KVM driver
 kvm = ["kvmi"]
 # VirtualBox driver
@@ -29,7 +29,7 @@ log = "0.4.8"
 env_logger = "0.7.1"
 libc = { version = "0.2.58", optional = true }
 xenctrl = { git = "https://github.com/Wenzel/xenctrl", optional = true }
-xenstore = { git = "https://github.com/Wenzel/xenstore", rev = 'e8627acfe73186eb7cc34385d531058d3c55643d', optional = true }
+xenstore-rs = { version = "0.3.0", optional = true }
 xenforeignmemory = { git = "https://github.com/Wenzel/xenforeignmemory", optional = true }
 kvmi = { version = "0.2.1", optional = true }
 fdp = { version = "0.1.0", optional = true }

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -5,7 +5,7 @@ use libc::{PROT_READ, PROT_WRITE};
 use std::error::Error;
 use xenctrl::consts::{PAGE_SHIFT, PAGE_SIZE};
 use xenctrl::XenControl;
-use xenstore::{XBTransaction, Xs, XsOpenFlags};
+use xenstore_rs::{XBTransaction, Xs, XsOpenFlags};
 
 // unit struct
 #[derive(Debug)]


### PR DESCRIPTION
This should help fix #127 and #125 

Depends on this sub-PR:
https://github.com/Wenzel/xenstore/pull/7