### PR TITLE
cargo: pin xenstore revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4.8"
 env_logger = "0.7.1"
 libc = { version = "0.2.58", optional = true }
 xenctrl = { git = "https://github.com/Wenzel/xenctrl", optional = true }
-xenstore = { git = "https://github.com/Wenzel/xenstore", optional = true }
+xenstore = { git = "https://github.com/Wenzel/xenstore", rev = 'e8627acfe73186eb7cc34385d531058d3c55643d', optional = true }
 xenforeignmemory = { git = "https://github.com/Wenzel/xenforeignmemory", optional = true }
 kvmi = { version = "0.2.1", optional = true }
 fdp = { version = "0.1.0", optional = true }


### PR DESCRIPTION
This pins the version of xenstore, to avoid breakage with our last updates on xenstore master