### PR TITLE
Better error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ hyper-v = ["winapi", "widestring", "ntapi", "vid-sys"]
 [dependencies]
 log = "0.4.8"
 env_logger = "0.7.1"
+thiserror = "1.0.23"
 libc = { version = "0.2.58", optional = true }
 xenctrl = { version = "0.4.2", optional = true }
 xenstore-rs = { version = "0.3.0", optional = true }

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,6 +3,8 @@ use std::ffi::{CStr, IntoStringError};
 
 use crate::capi::DriverInitParamFFI;
 use crate::driver::dummy::DummyDriverError;
+#[cfg(feature = "virtualbox")]
+use crate::driver::virtualbox::VirtualBoxDriverError;
 
 bitflags! {
     pub struct Access: u32 {
@@ -186,6 +188,9 @@ pub enum MicrovmiError {
 pub enum DriverError {
     #[error(transparent)]
     Dummy(#[from] DummyDriverError),
+    #[cfg(feature = "virtualbox")]
+    #[error(transparent)]
+    VirtualBox(#[from] VirtualBoxDriverError),
 }
 
 pub trait Introspectable {

--- a/src/api.rs
+++ b/src/api.rs
@@ -177,7 +177,10 @@ pub const PAGE_SHIFT: u32 = 12;
 pub const PAGE_SIZE: u32 = 4096;
 
 #[derive(thiserror::Error, Debug)]
-pub enum MicrovmiError {}
+pub enum MicrovmiError {
+    #[error(transparent)]
+    DriverError(#[from] DriverError),
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum DriverError {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 use std::error::Error;
 use std::ffi::{CStr, IntoStringError};
+use thiserror;
 
 use crate::capi::DriverInitParamFFI;
 
@@ -175,6 +176,9 @@ pub enum Registers {
 
 pub const PAGE_SHIFT: u32 = 12;
 pub const PAGE_SIZE: u32 = 4096;
+
+#[derive(thiserror::Error, Debug)]
+pub enum MicrovmiError {}
 
 pub trait Introspectable {
     /// Retrieve the number of VCPUs.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,9 +1,8 @@
 use std::convert::TryInto;
-use std::error::Error;
 use std::ffi::{CStr, IntoStringError};
-use thiserror;
 
 use crate::capi::DriverInitParamFFI;
+use crate::driver::dummy::DummyDriverError;
 
 bitflags! {
     pub struct Access: u32 {
@@ -180,10 +179,16 @@ pub const PAGE_SIZE: u32 = 4096;
 #[derive(thiserror::Error, Debug)]
 pub enum MicrovmiError {}
 
+#[derive(thiserror::Error, Debug)]
+pub enum DriverError {
+    #[error(transparent)]
+    Dummy(#[from] DummyDriverError),
+}
+
 pub trait Introspectable {
     /// Retrieve the number of VCPUs.
     ///
-    fn get_vcpu_count(&self) -> Result<u16, Box<dyn Error>> {
+    fn get_vcpu_count(&self) -> Result<u16, DriverError> {
         unimplemented!();
     }
 
@@ -194,7 +199,7 @@ pub trait Introspectable {
     /// * 'paddr' - the physical address to read from
     /// * 'buf' - the data read from memory
     ///
-    fn read_physical(&self, _paddr: u64, _buf: &mut [u8]) -> Result<(), Box<dyn Error>> {
+    fn read_physical(&self, _paddr: u64, _buf: &mut [u8]) -> Result<(), DriverError> {
         unimplemented!();
     }
 
@@ -205,7 +210,7 @@ pub trait Introspectable {
     /// * 'paddr' - the physical address to write into
     /// * 'buf' - the data to be written into memory
     ///
-    fn write_physical(&self, _paddr: u64, _buf: &mut [u8]) -> Result<(), Box<dyn Error>> {
+    fn write_physical(&self, _paddr: u64, _buf: &mut [u8]) -> Result<(), DriverError> {
         unimplemented!();
     }
 
@@ -213,7 +218,7 @@ pub trait Introspectable {
     ///
     /// Returns maximum physical address in 64 bit unsigned integer format.
     ///
-    fn get_max_physical_addr(&self) -> Result<u64, Box<dyn Error>> {
+    fn get_max_physical_addr(&self) -> Result<u64, DriverError> {
         unimplemented!();
     }
 
@@ -222,7 +227,7 @@ pub trait Introspectable {
     /// # Arguments
     /// * 'vcpu' - vcpu id for which the value of registers are to be dumped as the argument
     ///
-    fn read_registers(&self, _vcpu: u16) -> Result<Registers, Box<dyn Error>> {
+    fn read_registers(&self, _vcpu: u16) -> Result<Registers, DriverError> {
         unimplemented!();
     }
 
@@ -231,7 +236,7 @@ pub trait Introspectable {
     /// # Arguments
     /// * 'paddr' - physical address of the page whose access we want to know.
     ///
-    fn get_page_access(&self, _paddr: u64) -> Result<Access, Box<dyn Error>> {
+    fn get_page_access(&self, _paddr: u64) -> Result<Access, DriverError> {
         unimplemented!();
     }
 
@@ -241,7 +246,7 @@ pub trait Introspectable {
     /// * 'paddr' - physical address of the page whose access we want to set
     /// * 'access' - access flags to be set on the given page
     ///
-    fn set_page_access(&self, _paddr: u64, _access: Access) -> Result<(), Box<dyn Error>> {
+    fn set_page_access(&self, _paddr: u64, _access: Access) -> Result<(), DriverError> {
         unimplemented!();
     }
 
@@ -251,19 +256,19 @@ pub trait Introspectable {
     /// * 'vcpu' - vcpu id for which the value of registers are to be set
     /// * 'reg' - Registers enum having values to be set
     ///
-    fn write_registers(&self, _vcpu: u16, _reg: Registers) -> Result<(), Box<dyn Error>> {
+    fn write_registers(&self, _vcpu: u16, _reg: Registers) -> Result<(), DriverError> {
         unimplemented!();
     }
 
     /// Used to pause the VM
     ///
-    fn pause(&mut self) -> Result<(), Box<dyn Error>> {
+    fn pause(&mut self) -> Result<(), DriverError> {
         unimplemented!();
     }
 
     /// Used to resume the VM
     ///
-    fn resume(&mut self) -> Result<(), Box<dyn Error>> {
+    fn resume(&mut self) -> Result<(), DriverError> {
         unimplemented!();
     }
 
@@ -279,7 +284,7 @@ pub trait Introspectable {
         _vcpu: u16,
         _intercept_type: InterceptType,
         _enabled: bool,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), DriverError> {
         unimplemented!();
     }
 
@@ -288,7 +293,7 @@ pub trait Introspectable {
     /// # Arguments
     /// * 'timeout' - Time for which it will wait for a new event
     ///
-    fn listen(&mut self, _timeout: u32) -> Result<Option<Event>, Box<dyn Error>> {
+    fn listen(&mut self, _timeout: u32) -> Result<Option<Event>, DriverError> {
         unimplemented!();
     }
 
@@ -302,7 +307,7 @@ pub trait Introspectable {
         &mut self,
         _event: Event,
         _reply_type: EventReplyType,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), DriverError> {
         unimplemented!();
     }
 }

--- a/src/driver/dummy.rs
+++ b/src/driver/dummy.rs
@@ -10,9 +10,12 @@ pub enum DummyDriverError {
 pub struct Dummy;
 
 impl Dummy {
-    pub fn new(domain_name: &str, _init_option: Option<DriverInitParam>) -> Self {
+    pub fn new(
+        domain_name: &str,
+        _init_option: Option<DriverInitParam>,
+    ) -> Result<Self, DriverError> {
         debug!("init on {}", domain_name);
-        Dummy
+        Ok(Dummy)
     }
 }
 

--- a/src/driver/dummy.rs
+++ b/src/driver/dummy.rs
@@ -1,5 +1,10 @@
-use crate::api::{DriverInitParam, Introspectable};
-use std::error::Error;
+use crate::api::{DriverError, DriverInitParam, Introspectable};
+
+#[derive(thiserror::Error, Debug)]
+pub enum DummyDriverError {
+    #[error("dummy error")]
+    DummyError,
+}
 
 // unit struct
 pub struct Dummy;
@@ -12,22 +17,25 @@ impl Dummy {
 }
 
 impl Introspectable for Dummy {
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(), Box<dyn Error>> {
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(), DriverError> {
         debug!("read physical - @{}, {:#?}", paddr, buf);
+        if paddr == 0 {
+            return Err(DummyDriverError::DummyError.into());
+        }
         Ok(())
     }
 
-    fn get_max_physical_addr(&self) -> Result<u64, Box<dyn Error>> {
+    fn get_max_physical_addr(&self) -> Result<u64, DriverError> {
         debug!("get max physical address");
         Ok(0)
     }
 
-    fn pause(&mut self) -> Result<(), Box<dyn Error>> {
+    fn pause(&mut self) -> Result<(), DriverError> {
         debug!("pause");
         Ok(())
     }
 
-    fn resume(&mut self) -> Result<(), Box<dyn Error>> {
+    fn resume(&mut self) -> Result<(), DriverError> {
         debug!("resume");
         Ok(())
     }

--- a/src/driver/virtualbox.rs
+++ b/src/driver/virtualbox.rs
@@ -3,8 +3,15 @@ use std::error::Error;
 use fdp::{RegisterType, FDP};
 
 use crate::api::{
-    DriverInitParam, Introspectable, Registers, SegmentReg, SystemTableReg, X86Registers,
+    DriverError, DriverInitParam, Introspectable, Registers, SegmentReg, SystemTableReg,
+    X86Registers,
 };
+
+#[derive(thiserror::Error, Debug)]
+pub enum VirtualBoxDriverError {
+    #[error(transparent)]
+    OtherError(#[from] Box<dyn Error>),
+}
 
 // unit struct
 #[derive(Debug)]
@@ -21,85 +28,188 @@ impl VBox {
 }
 
 impl Introspectable for VBox {
-    fn get_vcpu_count(&self) -> Result<u16, Box<dyn Error>> {
+    fn get_vcpu_count(&self) -> Result<u16, DriverError> {
         // no API to fetch VCPU count, hardcode to 1 for now
         Ok(1)
     }
 
-    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(), Box<dyn Error>> {
-        self.fdp.read_physical_memory(paddr, buf)
+    fn read_physical(&self, paddr: u64, buf: &mut [u8]) -> Result<(), DriverError> {
+        self.fdp
+            .read_physical_memory(paddr, buf)
+            .map_err(|err| VirtualBoxDriverError::OtherError(err).into())
     }
 
-    fn get_max_physical_addr(&self) -> Result<u64, Box<dyn Error>> {
-        self.fdp.get_physical_memory_size()
+    fn get_max_physical_addr(&self) -> Result<u64, DriverError> {
+        self.fdp
+            .get_physical_memory_size()
+            .map_err(|err| VirtualBoxDriverError::OtherError(err).into())
     }
 
-    fn read_registers(&self, vcpu: u16) -> Result<Registers, Box<dyn Error>> {
+    fn read_registers(&self, vcpu: u16) -> Result<Registers, DriverError> {
         let fdp_vcpu = vcpu as u32;
         let regs = X86Registers {
-            rax: self.fdp.read_register(fdp_vcpu, RegisterType::RAX)?,
-            rbx: self.fdp.read_register(fdp_vcpu, RegisterType::RBX)?,
-            rcx: self.fdp.read_register(fdp_vcpu, RegisterType::RCX)?,
-            rdx: self.fdp.read_register(fdp_vcpu, RegisterType::RDX)?,
-            rsi: self.fdp.read_register(fdp_vcpu, RegisterType::RSI)?,
-            rdi: self.fdp.read_register(fdp_vcpu, RegisterType::RDI)?,
-            rbp: self.fdp.read_register(fdp_vcpu, RegisterType::RBP)?,
-            rsp: self.fdp.read_register(fdp_vcpu, RegisterType::RSP)?,
-            r8: self.fdp.read_register(fdp_vcpu, RegisterType::R8)?,
-            r9: self.fdp.read_register(fdp_vcpu, RegisterType::R9)?,
-            r10: self.fdp.read_register(fdp_vcpu, RegisterType::R10)?,
-            r11: self.fdp.read_register(fdp_vcpu, RegisterType::R11)?,
-            r12: self.fdp.read_register(fdp_vcpu, RegisterType::R12)?,
-            r13: self.fdp.read_register(fdp_vcpu, RegisterType::R13)?,
-            r14: self.fdp.read_register(fdp_vcpu, RegisterType::R14)?,
-            r15: self.fdp.read_register(fdp_vcpu, RegisterType::R15)?,
-            rip: self.fdp.read_register(fdp_vcpu, RegisterType::RIP)?,
-            cr0: self.fdp.read_register(fdp_vcpu, RegisterType::CR0)?,
-            cr2: self.fdp.read_register(fdp_vcpu, RegisterType::CR2)?,
-            cr3: self.fdp.read_register(fdp_vcpu, RegisterType::CR3)?,
-            cr4: self.fdp.read_register(fdp_vcpu, RegisterType::CR4)?,
+            rax: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RAX)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            rbx: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RBX)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            rcx: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RCX)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            rdx: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RDX)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            rsi: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RSI)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            rdi: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RDI)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            rbp: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RBP)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            rsp: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RSP)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            r8: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::R8)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            r9: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::R9)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            r10: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::R10)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            r11: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::R11)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            r12: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::R12)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            r13: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::R13)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            r14: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::R14)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            r15: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::R15)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            rip: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::RIP)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            cr0: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::CR0)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            cr2: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::CR2)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            cr3: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::CR3)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+            cr4: self
+                .fdp
+                .read_register(fdp_vcpu, RegisterType::CR4)
+                .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
             cs: SegmentReg {
-                base: self.fdp.read_register(fdp_vcpu, RegisterType::CS)?,
+                base: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::CS)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
                 ..Default::default()
             },
             ds: SegmentReg {
-                base: self.fdp.read_register(fdp_vcpu, RegisterType::DS)?,
+                base: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::DS)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
                 ..Default::default()
             },
             es: SegmentReg {
-                base: self.fdp.read_register(fdp_vcpu, RegisterType::ES)?,
+                base: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::ES)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
                 ..Default::default()
             },
             fs: SegmentReg {
-                base: self.fdp.read_register(fdp_vcpu, RegisterType::FS)?,
+                base: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::FS)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
                 ..Default::default()
             },
             gs: SegmentReg {
-                base: self.fdp.read_register(fdp_vcpu, RegisterType::GS)?,
+                base: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::GS)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
                 ..Default::default()
             },
             ss: SegmentReg {
-                base: self.fdp.read_register(fdp_vcpu, RegisterType::SS)?,
+                base: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::SS)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
                 ..Default::default()
             },
             gdt: SystemTableReg {
-                base: self.fdp.read_register(fdp_vcpu, RegisterType::GDTR_BASE)?,
-                limit: self.fdp.read_register(fdp_vcpu, RegisterType::GDTR_LIMIT)? as u16,
+                base: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::GDTR_BASE)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+                limit: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::GDTR_LIMIT)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?
+                    as u16,
             },
             idt: SystemTableReg {
-                base: self.fdp.read_register(fdp_vcpu, RegisterType::IDTR_BASE)?,
-                limit: self.fdp.read_register(fdp_vcpu, RegisterType::IDTR_LIMIT)? as u16,
+                base: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::IDTR_BASE)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?,
+                limit: self
+                    .fdp
+                    .read_register(fdp_vcpu, RegisterType::IDTR_LIMIT)
+                    .map_err(|err| DriverError::from(VirtualBoxDriverError::OtherError(err)))?
+                    as u16,
             },
             ..Default::default()
         };
         Ok(Registers::X86(regs))
     }
 
-    fn pause(&mut self) -> Result<(), Box<dyn Error>> {
-        self.fdp.pause()
+    fn pause(&mut self) -> Result<(), DriverError> {
+        self.fdp
+            .pause()
+            .map_err(|err| VirtualBoxDriverError::OtherError(err).into())
     }
 
-    fn resume(&mut self) -> Result<(), Box<dyn Error>> {
-        self.fdp.resume()
+    fn resume(&mut self) -> Result<(), DriverError> {
+        self.fdp
+            .resume()
+            .map_err(|err| VirtualBoxDriverError::OtherError(err).into())
     }
 }

--- a/src/driver/virtualbox.rs
+++ b/src/driver/virtualbox.rs
@@ -20,10 +20,13 @@ pub struct VBox {
 }
 
 impl VBox {
-    pub fn new(domain_name: &str, _init_option: Option<DriverInitParam>) -> Self {
+    pub fn new(
+        domain_name: &str,
+        _init_option: Option<DriverInitParam>,
+    ) -> Result<Self, DriverError> {
         // init FDP
         let fdp = FDP::new(domain_name);
-        VBox { fdp }
+        Ok(VBox { fdp })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub fn init(
             DriverType::KVM => create_kvm(domain_name, init_option),
             #[cfg(feature = "virtualbox")]
             DriverType::VirtualBox => {
-                Box::new(VBox::new(domain_name, init_option)) as Box<dyn Introspectable>
+                Box::new(VBox::new(domain_name, init_option)?) as Box<dyn Introspectable>
             }
             #[cfg(feature = "xen")]
             DriverType::Xen => {
@@ -67,7 +67,9 @@ pub fn init(
             // test VirtualBox
             #[cfg(feature = "virtualbox")]
             {
-                return Ok(Box::new(VBox::new(domain_name, init_option)) as Box<dyn Introspectable>);
+                return Ok(
+                    Box::new(VBox::new(domain_name, init_option)?) as Box<dyn Introspectable>
+                );
             }
 
             // test Xen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub fn init(
     Ok(match driver_type {
         Some(drv_type) => match drv_type {
             DriverType::Dummy => {
-                Box::new(Dummy::new(domain_name, init_option)) as Box<dyn Introspectable>
+                Box::new(Dummy::new(domain_name, init_option)?) as Box<dyn Introspectable>
             }
             #[cfg(feature = "hyper-v")]
             DriverType::HyperV => {
@@ -76,7 +76,7 @@ pub fn init(
                 return Ok(Box::new(Xen::new(domain_name, init_option)) as Box<dyn Introspectable>);
             }
             // return Dummy if no other driver has been compiled
-            Box::new(Dummy::new(domain_name, init_option)) as Box<dyn Introspectable>
+            Box::new(Dummy::new(domain_name, init_option)?) as Box<dyn Introspectable>
         }
     })
 }


### PR DESCRIPTION
This PR is a draft to implement precise error types in libmicrovmi.

It tries to improve @rageagainsthepc 's https://github.com/Wenzel/libmicrovmi/pull/152, by removing the DriverError trait and returning only clearly defined enums.

All the trait function definition have been moved to returning `Result<T, DriverError>`
Contrary to what I said https://github.com/Wenzel/libmicrovmi/pull/152#issuecomment-753631651 about boxing errors, i attempted here to remove any boxing, since:
- there is no trait anymore, so the size is known
- we don't know yet if we actually really need to box our errors because of the stack size with large error types. this is something i would like to discuss with members of the rust community
- boxing makes the code a bit less readable

the new trait definition has been implemented on:
- Dummy
- VirtualBox

Furthermore, the `init` function for these 2 drivers is now fallible

new error types:
- `MicrovmiError`
- `DriverError`
- `DummyDriverError` and `VirtualBoxDriverError`

Last thing, I will switch the error types to be `#[non_exhaustive]` to better understand all the implications when updating an driver error type.