### PR TITLE
Add gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,25 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get update \
+    && sudo apt-get install -y --no-install-recommends clang libxen-dev \
+    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/
+
+RUN git clone -b kvmi-v6 https://github.com/bitdefender/libkvmi.git \
+    && cd libkvmi \
+    && ./bootstrap \
+    && ./configure \
+    && make \
+    && sudo make install \
+    && cd .. \
+    && rm -rf libkvmi
+
+RUN git clone --depth 1 https://github.com/thalium/icebox \
+    && cd icebox/src/FDP \
+    && g++ -std=c++11 -shared -fPIC FDP.cpp -o libFDP.so \
+    && sudo mv include/* /usr/local/include/ \
+    && sudo mv libFDP.so /usr/local/lib/ \
+    && cd - \
+    && rm -rf icebox
+
+RUN cargo install cbindgen \
+    && rustup component add clippy rustfmt

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,22 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: cargo build --features kvm,virtualbox,xen
+
+vscode:
+  extensions:
+    # Theia does not support rust-analyzer, therefore this plugin list targets vscode instead. 
+    - editorconfig.editorconfig
+    - rust-lang.rust
+    - matklad.rust-analyzer
+    - eamodio.gitlens
+    - serayuzgur.crates
+    - belfz.search-crates-io
+    - bungcip.better-toml
+
+github:
+  prebuilds:
+    branches: true
+    addCheck: false
+    addComment: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Join the chat at https://gitter.im/libmicrovmi/community](https://badges.gitter.im/libmicrovmi/community.svg)](https://gitter.im/libmicrovmi/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![tokei](https://tokei.rs/b1/github/Wenzel/libmicrovmi)](https://github.com/Wenzel/libmicrovmi)
 [![repo size](https://img.shields.io/github/repo-size/Wenzel/libmicrovmi)](https://github.com/Wenzel/libmicrovmi)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/Wenzel/libmicrovmi)
 
 > A cross-platform unified interface on top of hypervisor's VMI APIs
 


### PR DESCRIPTION
Gitpod provides Web IDEs which I think work already really well. I can definitely see myself using those instead of a local IDE (unless I have to actually run the code of course). It should also be handy for new people who want to explore the repo. However, I've enabled experimental features in order to be able to use VSCode instead of Theia because the rust-analyzer plugin does not work with the latter.

Edit: I should mention that experimental features are an account setting unfortunately. 