### PR TITLE
Driver error enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1.0"
 libc = { version = "0.2", optional = true }
 xenctrl = { version = "0.4.2", optional = true }
 xenstore-rs = { version = "0.3.0", optional = true }
-xenforeignmemory = { version = "0.1.0", optional = true }
+xenforeignmemory = { version = "0.2.1", optional = true }
 xenevtchn = { version = "0.1.2", optional = true }
 xenvmevent-sys = { version = "0.1.3", optional = true }
 kvmi = { version = "0.2.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ hyper-v = ["winapi", "widestring", "ntapi", "vid-sys"]
 [dependencies]
 log = "0.4"
 env_logger = "0.8"
+bitflags = "1.2.1"
+cty = "0.2.1"
+nix = "0.19"
 libc = { version = "0.2", optional = true }
 xenctrl = { version = "0.4.2", optional = true }
 xenstore-rs = { version = "0.3.0", optional = true }
@@ -39,9 +42,7 @@ winapi = { version = "0.3", features = ["tlhelp32", "winnt", "handleapi", "secur
 widestring = { version = "0.4", optional = true }
 ntapi = { version = "0.3", optional = true }
 vid-sys = { version = "0.3.0", features = ["deprecated-apis"], optional = true }
-bitflags = "1.2.1"
-cty = "0.2.1"
-nix = "0.19"
+
 
 [dev-dependencies]
 ctrlc = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ env_logger = "0.8"
 bitflags = "1.2.1"
 cty = "0.2.1"
 nix = "0.19"
+thiserror = "1.0"
 libc = { version = "0.2", optional = true }
 xenctrl = { version = "0.4.2", optional = true }
 xenstore-rs = { version = "0.3.0", optional = true }


### PR DESCRIPTION
This PR adds driver specific error types based on `thiserror` for Xen and KVM

regarding virtualbox, the FDP crate returns `Box<dyn Error>` for every function, so implementing a better handling for this driver will start with FDP library.