### PR TITLE
cargo: upgrade kvmi to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ xenstore-rs = { version = "=0.3.0", optional = true }
 xenforeignmemory = { version = "=0.2.1", optional = true }
 xenevtchn = { version = "=0.1.2", optional = true }
 xenvmevent-sys = { version = "=0.1.3", optional = true }
-kvmi = { version = "=0.2.4", optional = true }
+kvmi = { version = "0.3.0", optional = true }
 fdp = { version = "=0.1.0", optional = true }
 winapi = { version = "0.3", features = ["tlhelp32", "winnt", "handleapi", "securitybaseapi"], optional = true }
 widestring = { version = "0.4", optional = true }


### PR DESCRIPTION
Following https://github.com/Wenzel/libmicrovmi/pull/170#issuecomment-784152381