### PR TITLE
ci: package libmicrovmi.h header in Debian package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,17 +190,14 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - name: install cbindgen
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cbindgen
-          version: latest
-          use-tool-cache: true
+
       - uses: actions/checkout@v1
+
       - name: build libmicrovmi
         uses: actions-rs/cargo@v1
         with:
           command: build
+
       - name: build C API
         run: |
           cd c_examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,34 @@ jobs:
       - name: install Xen headers
         run: sudo apt-get install -y libxen-dev
 
+      - name: clone Icebox
+        uses: actions/checkout@v2
+        with:
+          repository: thalium/icebox
+          path: icebox
+
+      - name: install VirtualBox's FDP headers
+        run: |
+          g++ -std=c++11 -shared -fPIC FDP.cpp -o libFDP.so
+          sudo cp include/* /usr/local/include
+          sudo cp libFDP.so /usr/local/lib
+        working-directory: icebox/src/FDP
+
+      - name: clone libkvmi
+        uses: actions/checkout@v2
+        with:
+          repository: bitdefender/libkvmi
+          path: libkvmi
+          ref: bf5776319e1801b59125c994c459446f0ed6837e
+
+      - name: build and install libkvmi
+        run: |
+          ./bootstrap
+          ./configure
+          make
+          sudo make install
+        working-directory: libkvmi
+
       - name: install cargo deb dependencies
         run: sudo apt-get install -y dpkg liblzma-dev
 
@@ -251,7 +279,7 @@ jobs:
         run: cargo install cargo-deb
 
       - name: build debian package
-        run: cargo deb -- --features xen
+        run: cargo deb -- --features xen,kvm,virtualbox
 
       - name: upload artifact
         uses: actions/upload-artifact@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,21 @@ colored = "2.0"
 mockall = "0.9"
 test-case = "1"
 indicatif = "0.15.0"
+
+
+[build-dependencies]
+cbindgen = "0.18.0"
+
+
+[package.metadata.deb]
+extended-description = "A simple virtual machine introspection library providing a cross-platform interface on multiple hypervisors"
+# force an old enough libc6
+# otherwise, the current libc of the CI is taken, and it will be too recent
+depends = "libc6 (>= 2.19)"
+section = "libs"
+priority = "optional"
+# add generated libmicrovmi.h header
+assets = [
+    ["target/release/libmicrovmi.so", "usr/lib/libmicrovmi.so", "644"],
+    ["c_examples/libmicrovmi.h", "usr/include/libmicrovmi.h", "644"],
+]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,25 @@
+//! This build script will run cbindgen to generate libmicrovmi C header file
+
+use std::env;
+use std::path::Path;
+
+use cbindgen::Config;
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let out_path = Path::new(&crate_dir).join("c_examples/libmicrovmi.h");
+
+    let config = Config::from_root_or_default(&crate_dir);
+
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file(out_path);
+
+    println!("cargo:rerun-if-changed=src/capi.rs");
+    // if it has been removed
+    println!("cargo:rerun-if-changed=c_examples/libmicrovmi.h");
+}


### PR DESCRIPTION
- Compile Xen, KVM and VirtualBox drivers for debian packaged libmicrovmi.so
- package `libmicrovmi.h` in the Debian package
![Capture d’écran de 2021-03-02 16-03-47](https://user-images.githubusercontent.com/964610/109667998-01674c80-7b71-11eb-9754-f12c4da414c3.png)


Note: I'm not a big fan of using `build.rs` to generate a file outside `OUT_DIR` env var, since it's not recommended.
_"In general, build scripts should not modify any files outside of OUT_DIR. It may seem fine on the first blush, but it does cause problems when you use such crate as a dependency, because there's an implicit invariant that sources in .cargo/registry should be immutable. cargo won't allow such scripts when packaging."_

However, I needed to specify a non dynamically configurable path in Cargo-deb's assets field, so I choose this method.

