### PR TITLE
cargo: fix location of generated file libmcrovmi.h

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,5 +69,5 @@ priority = "optional"
 # add generated libmicrovmi.h header
 assets = [
     ["target/release/libmicrovmi.so", "usr/lib/libmicrovmi.so", "644"],
-    ["c_examples/libmicrovmi.h", "usr/include/libmicrovmi.h", "644"],
+    ["target/release/capi/libmicrovmi.h", "usr/include/libmicrovmi.h", "644"],
 ]

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,31 @@
 //! This build script will run cbindgen to generate libmicrovmi C header file
 
 use std::env;
-use std::path::Path;
+use std::fs;
+use std::path::PathBuf;
 
 use cbindgen::Config;
 
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    let out_path = Path::new(&crate_dir).join("c_examples/libmicrovmi.h");
+    // a little hack to write outside of OUT_DIR
+    // https://github.com/mmstick/cargo-deb/blob/e43018a46b8dc922cfdf6cdde12f7ed92fcc41aa/example/build.rs
+    // libmicrovmi issue: https://github.com/Wenzel/libmicrovmi/issues/177
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let mut out_path = PathBuf::from(&out_dir)
+        .ancestors() // .../target/<debug|release>/build/example-<SHA>/out
+        .nth(3) // .../target/<debug|release>
+        .unwrap()
+        .to_owned();
+    out_path.push("capi");
+    // .../target/<debug|release>/capi/
+
+    if !out_path.exists() {
+        fs::create_dir(&out_path).expect("Could not create capi dir");
+    }
+    // .../target/<debug|release>/capi/libmicrovmi.h
+    out_path.push("libmicrovmi.h");
 
     let config = Config::from_root_or_default(&crate_dir);
 
@@ -21,5 +38,5 @@ fn main() {
 
     println!("cargo:rerun-if-changed=src/capi.rs");
     // if it has been removed
-    println!("cargo:rerun-if-changed=c_examples/libmicrovmi.h");
+    println!("cargo:rerun-if-changed=target/capi/libmicrovmi.h");
 }


### PR DESCRIPTION
fix https://github.com/Wenzel/libmicrovmi/issues/177

There is standard solution avaialble right now, they are discussed on the rust-lang.
This should be considered a workaround in the meantime