### PR TITLE
capi: reintroduce get_driver_type

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -298,6 +298,9 @@ pub trait Introspectable {
     ) -> Result<(), Box<dyn Error>> {
         unimplemented!();
     }
+
+    /// Return the concrete DriverType
+    fn get_driver_type(&self) -> DriverType;
 }
 
 /// Various types of intercepts handled by libmicrovmi

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -133,6 +133,14 @@ pub unsafe extern "C" fn microvmi_read_registers(
     }
 }
 
+/// return the concrete DriverType for the given Microvmi driver
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn microvmi_get_driver_type(context: *mut c_void) -> DriverType {
+    let drv = get_driver_mut_ptr(context);
+    (*drv).get_driver_type()
+}
+
 unsafe fn get_driver_mut_ptr(context: *mut c_void) -> *mut dyn Introspectable {
     let driver: *mut *mut dyn Introspectable = context as *mut _;
     driver.read()

--- a/src/driver/hyperv.rs
+++ b/src/driver/hyperv.rs
@@ -7,7 +7,7 @@ use std::ptr::{null, null_mut};
 use std::slice;
 use std::vec::Vec;
 
-use crate::api::{DriverInitParam, Introspectable};
+use crate::api::{DriverInitParam, DriverType, Introspectable};
 
 use ntapi::ntexapi::{
     NtQuerySystemInformation, SystemHandleInformation, SYSTEM_HANDLE_INFORMATION,
@@ -259,7 +259,11 @@ impl HyperV {
     }
 }
 
-impl Introspectable for HyperV {}
+impl Introspectable for HyperV {
+    fn get_driver_type(&self) -> DriverType {
+        DriverType::HyperV
+    }
+}
 
 impl Drop for HyperV {
     fn drop(&mut self) {

--- a/src/driver/kvm.rs
+++ b/src/driver/kvm.rs
@@ -12,7 +12,7 @@ use std::mem;
 use std::vec::Vec;
 
 use crate::api::{
-    Access, CrType, DriverInitParam, Event, EventReplyType, EventType, InterceptType,
+    Access, CrType, DriverInitParam, DriverType, Event, EventReplyType, EventType, InterceptType,
     Introspectable, Registers, SegmentReg, SystemTableReg, X86Registers,
 };
 use kvmi::constants::PAGE_SIZE;
@@ -335,6 +335,10 @@ impl<T: KVMIntrospectable> Introspectable for Kvm<T> {
         let vcpu_index: usize = event.vcpu.try_into()?;
         let kvmi_event = mem::replace(&mut self.vec_events[vcpu_index], None).unwrap();
         Ok(self.kvmi.reply(&kvmi_event, kvm_reply_type)?)
+    }
+
+    fn get_driver_type(&self) -> DriverType {
+        DriverType::KVM
     }
 }
 

--- a/src/driver/virtualbox.rs
+++ b/src/driver/virtualbox.rs
@@ -3,7 +3,8 @@ use std::error::Error;
 use fdp::{RegisterType, FDP};
 
 use crate::api::{
-    DriverInitParam, Introspectable, Registers, SegmentReg, SystemTableReg, X86Registers,
+    DriverInitParam, DriverType, Introspectable, Registers, SegmentReg, SystemTableReg,
+    X86Registers,
 };
 
 // unit struct
@@ -104,5 +105,9 @@ impl Introspectable for VBox {
 
     fn resume(&mut self) -> Result<(), Box<dyn Error>> {
         self.fdp.resume()
+    }
+
+    fn get_driver_type(&self) -> DriverType {
+        DriverType::VirtualBox
     }
 }

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -1,6 +1,6 @@
 use crate::api::{
-    CrType, DriverInitParam, Event, EventType, InterceptType, Introspectable, Registers,
-    SegmentReg, SystemTableReg, X86Registers,
+    CrType, DriverInitParam, DriverType, Event, EventType, InterceptType, Introspectable,
+    Registers, SegmentReg, SystemTableReg, X86Registers,
 };
 use libc::{PROT_READ, PROT_WRITE};
 use nix::poll::PollFlags;
@@ -488,6 +488,10 @@ impl Introspectable for Xen {
             .xc
             .domain_unpause(self.domid)
             .map_err(XenDriverError::from)?)
+    }
+
+    fn get_driver_type(&self) -> DriverType {
+        DriverType::Xen
     }
 }
 


### PR DESCRIPTION
In order to solve https://github.com/Wenzel/libmicrovmi/issues/7 for Libvmi, we need to be able to get the concrete `DriverType` from the driver context.