### PR TITLE
vbox: FDP init is now fallible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ xenforeignmemory = { version = "=0.2.1", optional = true }
 xenevtchn = { version = "=0.1.2", optional = true }
 xenvmevent-sys = { version = "=0.1.3", optional = true }
 kvmi = { version = "0.3.0", optional = true }
-fdp = { version = "=0.1.0", optional = true }
+fdp = { version = "=0.2.0", optional = true }
 winapi = { version = "0.3", features = ["tlhelp32", "winnt", "handleapi", "securitybaseapi"], optional = true }
 widestring = { version = "0.4", optional = true }
 ntapi = { version = "0.3", optional = true }

--- a/src/driver/virtualbox.rs
+++ b/src/driver/virtualbox.rs
@@ -18,7 +18,7 @@ impl VBox {
         _init_option: Option<DriverInitParam>,
     ) -> Result<Self, Box<dyn Error>> {
         // init FDP
-        let fdp = FDP::new(domain_name);
+        let fdp = FDP::new(domain_name)?;
         Ok(VBox { fdp })
     }
 }


### PR DESCRIPTION
Avoid panicking when libFDP.so is not found on the system