### PR TITLE
Memory as file descriptor

### DIFF
--- a/examples/mem-dump.rs
+++ b/examples/mem-dump.rs
@@ -8,6 +8,7 @@ use log::trace;
 
 use microvmi::api::DriverInitParam;
 use microvmi::Microvmi;
+use std::io;
 
 const BUFFER_SIZE: usize = 64535; // 64K
 
@@ -85,8 +86,8 @@ fn main() {
         );
         // reset buffer each loop
         let mut buffer: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
-        let mut _bytes_read = 0;
-        drv.read_exact(&mut buffer)
+        drv.padded_memory
+            .read(&mut buffer)
             .expect(&*format!("Failed to read memory at {:#X}", cur_addr));
         dump_file
             .write_all(&buffer)

--- a/examples/mem-dump.rs
+++ b/examples/mem-dump.rs
@@ -9,7 +9,7 @@ use log::trace;
 use microvmi::api::DriverInitParam;
 use microvmi::Microvmi;
 
-const PAGE_SIZE: usize = 4096;
+const BUFFER_SIZE: usize = 64535; // 64K
 
 fn parse_args() -> ArgMatches<'static> {
     App::new(file!())
@@ -77,14 +77,14 @@ fn main() {
     // redraw every 0.1% change, otherwise it becomes the bottleneck
     bar.set_draw_delta(max_addr / 1000);
 
-    for cur_addr in (0..max_addr).step_by(PAGE_SIZE) {
+    for cur_addr in (0..max_addr).step_by(BUFFER_SIZE) {
         trace!(
             "reading {:#X} bytes of memory at {:#X}",
-            PAGE_SIZE,
+            BUFFER_SIZE,
             cur_addr
         );
         // reset buffer each loop
-        let mut buffer: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
+        let mut buffer: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
         let mut _bytes_read = 0;
         drv.read_exact(&mut buffer)
             .expect(&*format!("Failed to read memory at {:#X}", cur_addr));
@@ -93,7 +93,7 @@ fn main() {
             .expect("failed to write to file");
         // update bar
         bar.set_prefix(&*format!("{:#X}", cur_addr));
-        bar.inc(PAGE_SIZE as u64);
+        bar.inc(BUFFER_SIZE as u64);
     }
     bar.finish();
     println!(

--- a/examples/mem-dump.rs
+++ b/examples/mem-dump.rs
@@ -1,12 +1,13 @@
 use std::fs::File;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
 
 use clap::{App, Arg, ArgMatches};
 use indicatif::{ProgressBar, ProgressStyle};
-use log::{debug, trace};
+use log::trace;
 
-use microvmi::api::{DriverInitParam, Introspectable};
+use microvmi::api::DriverInitParam;
+use microvmi::Microvmi;
 
 const PAGE_SIZE: usize = 4096;
 
@@ -55,8 +56,8 @@ fn main() {
     let spinner = ProgressBar::new_spinner();
     spinner.enable_steady_tick(200);
     spinner.set_message("Initializing libmicrovmi...");
-    let mut drv: Box<dyn Introspectable> =
-        microvmi::init(domain_name, None, init_option).expect("Failed to init libmicrovmi");
+    let mut drv =
+        Microvmi::new(domain_name, None, init_option).expect("Failed to init libmicrovmi");
     spinner.finish_and_clear();
 
     println!("pausing the VM");
@@ -85,8 +86,8 @@ fn main() {
         // reset buffer each loop
         let mut buffer: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
         let mut _bytes_read = 0;
-        drv.read_physical(cur_addr, &mut buffer, &mut _bytes_read)
-            .unwrap_or_else(|_| debug!("failed to read memory at {:#X}", cur_addr));
+        drv.read_exact(&mut buffer)
+            .expect(&*format!("Failed to read memory at {:#X}", cur_addr));
         dump_file
             .write_all(&buffer)
             .expect("failed to write to file");

--- a/python/microvmi/memory.py
+++ b/python/microvmi/memory.py
@@ -94,13 +94,8 @@ class PaddedPhysicalMemoryIO(AbstractPhysicalMemoryIO):
         if size < 0:
             # -1: read all bytes until EOF
             raise NotImplementedError
-        data = bytearray(size)
-        for offset in range(0, size, PAGE_SIZE):
-            read_len = min(PAGE_SIZE, size - offset)
-            pos = self.tell()
-            chunk, _ = self._m.read_physical(pos, read_len)
-            end_offset = offset + read_len
-            data[offset:end_offset] = chunk
-            self.seek(read_len, SEEK_CUR)
-        self._log.debug("read return: len: %s, content: %s", len(data), data[:100])
-        return bytes(data)
+        pos = self.tell()
+        buffer, bytes_read = self._m.read_physical_padded(pos, size)
+        self.seek(size, SEEK_CUR)
+        self._log.debug("read return: len: %s, content: %s", len(buffer), buffer[:100])
+        return buffer

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -7,8 +7,9 @@ use pyo3::prelude::*;
 
 use errors::PyMicrovmiError;
 use microvmi::api as rapi; // rust api
-use microvmi::init;
+use microvmi::Microvmi;
 use pyo3::types::{PyByteArray, PyBytes};
+use std::io::{Read, Seek, SeekFrom};
 
 /// microvmi Python module declaration
 #[pymodule]
@@ -74,7 +75,7 @@ impl DriverInitParam {
 // compatible
 #[pyclass(unsendable)]
 struct MicrovmiExt {
-    driver: Box<dyn rapi::Introspectable>,
+    microvmi: Microvmi,
 }
 
 #[pymethods]
@@ -120,9 +121,9 @@ impl MicrovmiExt {
                     rapi::DriverInitParam::KVMiSocket(param.param_data_string)
                 }
             });
-        let driver =
-            init(domain_name, rust_driver_type, rust_init_param).map_err(PyMicrovmiError::from)?;
-        Ok(MicrovmiExt { driver })
+        let microvmi = Microvmi::new(domain_name, rust_driver_type, rust_init_param)
+            .map_err(PyMicrovmiError::from)?;
+        Ok(MicrovmiExt { microvmi })
     }
 
     /// read VM physical memory starting from paddr, of a given size
@@ -134,16 +135,15 @@ impl MicrovmiExt {
     /// Returns:
     ///     Tuple[bytes, int]: the read operation result and the amount bytes read
     fn read_physical<'p>(
-        &self,
+        &mut self,
         py: Python<'p>,
         paddr: u64,
         size: usize,
     ) -> PyResult<(&'p PyBytes, u64)> {
         let mut bytes_read: u64 = 0;
+        self.microvmi.memory.seek(SeekFrom::Start(paddr))?;
         let pybuffer: &PyBytes = PyBytes::new_with(py, size, |mut buffer| {
-            self.driver
-                .read_physical(paddr, &mut buffer, &mut bytes_read)
-                .ok();
+            bytes_read = self.microvmi.memory.read(&mut buffer).unwrap_or(0) as u64;
             Ok(())
         })?;
 
@@ -155,24 +155,22 @@ impl MicrovmiExt {
     /// Args:
     ///     paddr (int): the physical address to start reading from
     ///     buffer (bytearray): the buffer to read into
-    fn read_physical_into(&self, paddr: u64, buffer: &PyByteArray) -> u64 {
+    fn read_physical_into(&mut self, paddr: u64, buffer: &PyByteArray) -> PyResult<u64> {
         let mut_buf: &mut [u8] = unsafe { buffer.as_bytes_mut() };
-        let mut bytes_read: u64 = 0;
         // ignore read error
-        self.driver
-            .read_physical(paddr, mut_buf, &mut bytes_read)
-            .ok();
-        bytes_read
+        self.microvmi.memory.seek(SeekFrom::Start(paddr))?;
+        let bytes_read = self.microvmi.memory.read(mut_buf).unwrap_or(0) as u64;
+        Ok(bytes_read)
     }
 
     /// pause the VM
     fn pause(&mut self) -> PyResult<()> {
-        Ok(self.driver.pause().map_err(PyMicrovmiError::from)?)
+        Ok(self.microvmi.pause().map_err(PyMicrovmiError::from)?)
     }
 
     /// resume the VM
     fn resume(&mut self) -> PyResult<()> {
-        Ok(self.driver.resume().map_err(PyMicrovmiError::from)?)
+        Ok(self.microvmi.resume().map_err(PyMicrovmiError::from)?)
     }
 
     /// get maximum physical address
@@ -181,7 +179,7 @@ impl MicrovmiExt {
     ///     int: the maximum physical address
     fn get_max_physical_addr(&self) -> PyResult<u64> {
         let max_addr = self
-            .driver
+            .microvmi
             .get_max_physical_addr()
             .map_err(PyMicrovmiError::from)?;
         Ok(max_addr)

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use mockall::*;
 use std::convert::TryInto;
 use std::error::Error;
 use std::ffi::{CStr, IntoStringError};
@@ -172,6 +174,7 @@ pub enum Registers {
 pub const PAGE_SHIFT: u32 = 12;
 pub const PAGE_SIZE: u32 = 4096;
 
+#[cfg_attr(test, automock)]
 pub trait Introspectable {
     /// Retrieve the number of VCPUs.
     ///

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -4,6 +4,7 @@ use bitflags::_core::ptr::null_mut;
 use cty::{c_char, size_t, uint16_t, uint64_t, uint8_t};
 use std::convert::TryInto;
 use std::ffi::{c_void, CStr, CString};
+use std::io::{Read, Seek, SeekFrom};
 use std::slice;
 
 /// Support passing initialization options
@@ -78,15 +79,15 @@ pub unsafe extern "C" fn microvmi_destroy(context: *mut c_void) {
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn microvmi_pause(context: *mut c_void) -> bool {
-    let driver = get_driver_mut_ptr(context);
-    (*driver).pause().is_ok()
+    let mut driver = get_driver_mut_ptr(context);
+    driver.pause().is_ok()
 }
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn microvmi_resume(context: *mut c_void) -> bool {
-    let driver = get_driver_mut_ptr(context);
-    (*driver).resume().is_ok()
+    let mut driver = get_driver_mut_ptr(context);
+    driver.resume().is_ok()
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -98,19 +99,25 @@ pub unsafe extern "C" fn microvmi_read_physical(
     size: size_t,
     bytes_read: *mut uint64_t,
 ) -> bool {
-    let driver = get_driver_mut_ptr(context);
+    let mut driver = get_driver_mut_ptr(context);
 
-    let mut bytes_read_local = 0;
-    let res = (*driver)
-        .read_physical(
-            physical_address,
-            slice::from_raw_parts_mut(buffer, size),
-            &mut bytes_read_local,
-        )
-        .is_ok();
+    if driver
+        .memory
+        .seek(SeekFrom::Start(physical_address))
+        .is_err()
+    {
+        return false;
+    }
+
+    let mut res = false;
+    let read_res = driver.memory.read(slice::from_raw_parts_mut(buffer, size));
+    if read_res.is_ok() {
+        res = true;
+    }
+    let bytes_read_local = read_res.unwrap_or(0);
     // update bytes_read if not NULL
     if !bytes_read.is_null() {
-        bytes_read.write(bytes_read_local);
+        bytes_read.write(bytes_read_local as u64);
     }
     res
 }
@@ -122,7 +129,7 @@ pub unsafe extern "C" fn microvmi_get_max_physical_addr(
     address_ptr: *mut uint64_t,
 ) -> bool {
     let driver = get_driver_mut_ptr(context);
-    match (*driver).get_max_physical_addr() {
+    match driver.get_max_physical_addr() {
         Ok(max_addr) => {
             address_ptr.write(max_addr);
             true
@@ -139,7 +146,7 @@ pub unsafe extern "C" fn microvmi_read_registers(
     registers: *mut Registers,
 ) -> bool {
     let driver = get_driver_mut_ptr(context);
-    match (*driver).read_registers(vcpu) {
+    match driver.read_registers(vcpu) {
         Ok(regs) => {
             registers.write(regs);
             true
@@ -153,12 +160,12 @@ pub unsafe extern "C" fn microvmi_read_registers(
 #[no_mangle]
 pub unsafe extern "C" fn microvmi_get_driver_type(context: *mut c_void) -> DriverType {
     let drv = get_driver_mut_ptr(context);
-    (*drv).get_driver_type()
+    drv.get_driver_type()
 }
 
-unsafe fn get_driver_mut_ptr(context: *mut c_void) -> *mut dyn Introspectable {
-    let driver: *mut *mut dyn Introspectable = context as *mut _;
-    driver.read()
+unsafe fn get_driver_mut_ptr(context: *mut c_void) -> Microvmi {
+    let microvmi_box: *mut Microvmi = context as *mut _;
+    microvmi_box.read()
 }
 
 unsafe fn get_driver_box(context: *mut c_void) -> Box<Box<dyn Introspectable>> {

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,5 +1,5 @@
 use crate::api::{DriverInitParam, DriverType, Introspectable, Registers};
-use crate::init;
+use crate::microvmi::Microvmi;
 use bitflags::_core::ptr::null_mut;
 use cty::{c_char, size_t, uint16_t, uint64_t, uint8_t};
 use std::convert::TryInto;
@@ -55,8 +55,9 @@ pub unsafe extern "C" fn microvmi_init(
                 .expect("Failed to convert DriverInitParam C struct to Rust equivalent"),
         )
     };
-    match init(&safe_domain_name, optional_driver_type, init_option) {
-        Ok(driver) => Box::into_raw(Box::new(driver)) as *mut c_void,
+
+    match Microvmi::new(&safe_domain_name, optional_driver_type, init_option) {
+        Ok(m) => Box::into_raw(Box::new(m)) as *mut c_void,
         Err(err) => {
             if !init_error.is_null() {
                 (*init_error) = CString::new(format!("{}", err))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod driver;
 pub mod errors;
 mod memory;
 pub mod microvmi;
+pub use microvmi::Microvmi;
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,73 +6,10 @@ pub mod api;
 pub mod capi;
 mod driver;
 pub mod errors;
+mod memory;
+pub mod microvmi;
 
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate bitflags;
-
-use enum_iterator::IntoEnumIterator;
-
-use api::Introspectable;
-use api::{DriverInitParam, DriverType};
-#[cfg(feature = "kvm")]
-use driver::kvm::Kvm;
-#[cfg(feature = "virtualbox")]
-use driver::virtualbox::VBox;
-#[cfg(feature = "xen")]
-use driver::xen::Xen;
-use errors::MicrovmiError;
-#[cfg(feature = "kvm")]
-use kvmi::create_kvmi;
-
-pub fn init(
-    domain_name: &str,
-    driver_type: Option<DriverType>,
-    init_option: Option<DriverInitParam>,
-) -> Result<Box<dyn Introspectable>, MicrovmiError> {
-    info!("Microvmi init");
-    match driver_type {
-        None => {
-            // for each possible DriverType
-            for drv_type in DriverType::into_enum_iter() {
-                // try to init
-                match init_driver(domain_name, drv_type, init_option.clone()) {
-                    Ok(driver) => {
-                        return Ok(driver);
-                    }
-                    Err(e) => {
-                        debug!("{:?} driver initialization failed: {}", drv_type, e);
-                        continue;
-                    }
-                }
-            }
-            Err(MicrovmiError::NoDriverAvailable)
-        }
-        Some(drv_type) => init_driver(domain_name, drv_type, init_option),
-    }
-}
-
-/// Initialize a given driver type
-/// return None if the requested driver has not been compiled in libmicrovmi
-fn init_driver(
-    _domain_name: &str,
-    driver_type: DriverType,
-    _init_option: Option<DriverInitParam>,
-) -> Result<Box<dyn Introspectable>, MicrovmiError> {
-    #[allow(clippy::match_single_binding)]
-    match driver_type {
-        #[cfg(feature = "kvm")]
-        DriverType::KVM => Ok(Box::new(Kvm::new(
-            _domain_name,
-            create_kvmi(),
-            _init_option,
-        )?)),
-        #[cfg(feature = "virtualbox")]
-        DriverType::VirtualBox => Ok(Box::new(VBox::new(_domain_name, _init_option)?)),
-        #[cfg(feature = "xen")]
-        DriverType::Xen => Ok(Box::new(Xen::new(_domain_name, _init_option)?)),
-        #[allow(unreachable_patterns)]
-        _ => Err(MicrovmiError::DriverNotCompiled(driver_type)),
-    }
-}

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,5 +1,7 @@
 //! This module defines a physical memory implementation behaving like a File-IO
 
+#[cfg(test)]
+use crate::api::MockIntrospectable;
 use crate::microvmi::Microvmi;
 use std::convert::TryFrom;
 use std::io::Error;
@@ -65,18 +67,13 @@ impl Seek for Microvmi {
     fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
         match pos {
             SeekFrom::Start(p) => {
-                self.pos = self.pos.saturating_add(p);
-                if self.pos > self.max_addr {
-                    self.pos = self.max_addr;
-                }
+                self.pos = 0;
+                // force cast from u64 to i64, default to i64 MAX if conversion fail
+                self.seek(SeekFrom::Current(i64::try_from(p).unwrap_or(i64::MAX)))?;
             }
             SeekFrom::End(p) => {
-                if p > 0 {
-                    // seeking beyond the end of physical address space is not allowed
-                    self.pos = self.max_addr;
-                } else {
-                    self.pos = self.pos.saturating_sub(u64::try_from(-p).unwrap());
-                }
+                self.pos = self.max_addr;
+                self.seek(SeekFrom::Current(p))?;
             }
             SeekFrom::Current(p) => {
                 if p > 0 {
@@ -90,5 +87,69 @@ impl Seek for Microvmi {
             }
         };
         Ok(self.pos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_seek_start() -> Result<()> {
+        // create microvmi with mock driver
+        let mock_introspectable = MockIntrospectable::new();
+        let max_addr: u64 = 1000;
+        let mut microvmi = Microvmi {
+            drv: Box::new(mock_introspectable),
+            pos: 0,
+            max_addr,
+        };
+        // seek 0 doesn't move position
+        assert_eq!(0, microvmi.seek(SeekFrom::Start(0))?);
+        // seek beyond max_addr saturates at max_addr
+        assert_eq!(max_addr, microvmi.seek(SeekFrom::Start(max_addr + 1))?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_seek_end() -> Result<()> {
+        // create microvmi with mock driver
+        let mock_introspectable = MockIntrospectable::new();
+        let max_addr: u64 = 1000;
+        let mut microvmi = Microvmi {
+            drv: Box::new(mock_introspectable),
+            pos: 0,
+            max_addr,
+        };
+        // seek end should move to max_addr
+        assert_eq!(max_addr, microvmi.seek(SeekFrom::End(0))?);
+        // seek end beyond should saturates to max_addr
+        assert_eq!(max_addr, microvmi.seek(SeekFrom::End(50))?);
+        // seek end with a negative number should update the position
+        assert_eq!(max_addr - 50, microvmi.seek(SeekFrom::End(-50))?);
+        // seek below 0 should saturate at 0
+        assert_eq!(0, microvmi.seek(SeekFrom::End(i64::MIN))?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_seek_current() -> Result<()> {
+        // create microvmi with mock driver
+        let mock_introspectable = MockIntrospectable::new();
+        let max_addr: u64 = 1000;
+        let mut microvmi = Microvmi {
+            drv: Box::new(mock_introspectable),
+            pos: 0,
+            max_addr,
+        };
+        // seek current below 0 should saturate at 0
+        assert_eq!(0, microvmi.seek(SeekFrom::Current(-5))?);
+        // seek current should move the cursor
+        assert_eq!(50, microvmi.seek(SeekFrom::Current(50))?);
+        assert_eq!(49, microvmi.seek(SeekFrom::Current(-1))?);
+        assert_eq!(59, microvmi.seek(SeekFrom::Current(10))?);
+        // seek current beyond max_addr should saturate at max_addr
+        assert_eq!(max_addr, microvmi.seek(SeekFrom::Current(i64::MAX))?);
+        Ok(())
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -72,7 +72,9 @@ impl Seek for Microvmi {
                 self.seek(SeekFrom::Current(i64::try_from(p).unwrap_or(i64::MAX)))?;
             }
             SeekFrom::End(p) => {
-                self.pos = self.max_addr;
+                self.pos = self.drv.get_max_physical_addr().map_err(|_| {
+                    Error::new(ErrorKind::Other, "Failed to get maximum physical address")
+                })?;
                 self.seek(SeekFrom::Current(p))?;
             }
             SeekFrom::Current(p) => {
@@ -81,8 +83,11 @@ impl Seek for Microvmi {
                 } else {
                     self.pos = self.pos.saturating_sub(p.unsigned_abs());
                 }
-                if self.pos > self.max_addr {
-                    self.pos = self.max_addr;
+                let max_addr = self.drv.get_max_physical_addr().map_err(|_| {
+                    Error::new(ErrorKind::Other, "Failed to get maximum physical address")
+                })?;
+                if self.pos > max_addr {
+                    self.pos = max_addr;
                 }
             }
         };

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -3,7 +3,6 @@
 use crate::api::Introspectable;
 #[cfg(test)]
 use crate::api::MockIntrospectable;
-use crate::microvmi::Microvmi;
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::error::Error as StdError;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,94 @@
+//! This module defines a physical memory implementation behaving like a File-IO
+
+use crate::microvmi::Microvmi;
+use std::convert::TryFrom;
+use std::io::Error;
+use std::io::{ErrorKind, Result};
+use std::io::{Read, Seek, SeekFrom, Write};
+
+const PAGE_SIZE: usize = 4096;
+
+impl Read for Microvmi {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let mut total_bytes_read: usize = 0;
+        for chunk in buf.chunks_mut(PAGE_SIZE) {
+            let mut bytes_read: u64 = 0;
+            let paddr = self.stream_position()?;
+            self.drv
+                .read_physical(paddr, chunk, &mut bytes_read)
+                .map_err(|_| Error::new(ErrorKind::Other, "driver read failure"))?;
+            // advance pos from bytes_read
+            self.seek(SeekFrom::Current(bytes_read as i64))?;
+            // add to total
+            total_bytes_read += bytes_read as usize;
+        }
+        Ok(total_bytes_read)
+    }
+
+    /// Read the exact number of bytes required to fill buf.
+    ///
+    /// Read the physical memory and add padding to fill the blanks
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        let mut bytes_read: u64 = 0;
+        for chunk in buf.chunks_mut(PAGE_SIZE) {
+            let paddr = self.stream_position()?;
+            self.drv
+                .read_physical(paddr, chunk, &mut bytes_read)
+                .unwrap_or_else(|_| chunk.fill(0));
+            self.seek(SeekFrom::Current(chunk.len() as i64))?;
+        }
+        Ok(())
+    }
+}
+
+impl Write for Microvmi {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let mut total_bytes_written: usize = 0;
+        for chunk in buf.chunks(PAGE_SIZE) {
+            let paddr = self.stream_position()?;
+            self.drv
+                .write_physical(paddr, chunk)
+                .map_err(|_| Error::new(ErrorKind::Other, "driver write failure"))?;
+            self.seek(SeekFrom::Current(chunk.len() as i64))?;
+            total_bytes_written += chunk.len();
+        }
+        Ok(total_bytes_written)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        // nothing to do
+        Ok(())
+    }
+}
+
+impl Seek for Microvmi {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        match pos {
+            SeekFrom::Start(p) => {
+                self.pos = self.pos.saturating_add(p);
+                if self.pos > self.max_addr {
+                    self.pos = self.max_addr;
+                }
+            }
+            SeekFrom::End(p) => {
+                if p > 0 {
+                    // seeking beyond the end of physical address space is not allowed
+                    self.pos = self.max_addr;
+                } else {
+                    self.pos = self.pos.saturating_sub(u64::try_from(-p).unwrap());
+                }
+            }
+            SeekFrom::Current(p) => {
+                if p > 0 {
+                    self.pos = self.pos.saturating_add(p.unsigned_abs());
+                } else {
+                    self.pos = self.pos.saturating_sub(p.unsigned_abs());
+                }
+                if self.pos > self.max_addr {
+                    self.pos = self.max_addr;
+                }
+            }
+        };
+        Ok(self.pos)
+    }
+}

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -166,15 +166,12 @@ mod tests {
         // create microvmi with mock driver
         let mock_introspectable = MockIntrospectable::new();
         let max_addr: u64 = 1000;
-        let mut microvmi = Microvmi {
-            drv: Box::new(mock_introspectable),
-            pos: 0,
-            max_addr,
-        };
+        let drv = Rc::new(RefCell::new(Box::new(mock_introspectable)));
+        let mut memory = Memory::new(drv).unwrap();
         // seek 0 doesn't move position
-        assert_eq!(0, microvmi.seek(SeekFrom::Start(0))?);
+        assert_eq!(0, memory.seek(SeekFrom::Start(0))?);
         // seek beyond max_addr saturates at max_addr
-        assert_eq!(max_addr, microvmi.seek(SeekFrom::Start(max_addr + 1))?);
+        assert_eq!(max_addr, memory.seek(SeekFrom::Start(max_addr + 1))?);
         Ok(())
     }
 
@@ -183,19 +180,16 @@ mod tests {
         // create microvmi with mock driver
         let mock_introspectable = MockIntrospectable::new();
         let max_addr: u64 = 1000;
-        let mut microvmi = Microvmi {
-            drv: Box::new(mock_introspectable),
-            pos: 0,
-            max_addr,
-        };
+        let drv = Rc::new(RefCell::new(Box::new(mock_introspectable)));
+        let mut memory = Memory::new(drv).unwrap();
         // seek end should move to max_addr
-        assert_eq!(max_addr, microvmi.seek(SeekFrom::End(0))?);
+        assert_eq!(max_addr, memory.seek(SeekFrom::End(0))?);
         // seek end beyond should saturates to max_addr
-        assert_eq!(max_addr, microvmi.seek(SeekFrom::End(50))?);
+        assert_eq!(max_addr, memory.seek(SeekFrom::End(50))?);
         // seek end with a negative number should update the position
-        assert_eq!(max_addr - 50, microvmi.seek(SeekFrom::End(-50))?);
+        assert_eq!(max_addr - 50, memory.seek(SeekFrom::End(-50))?);
         // seek below 0 should saturate at 0
-        assert_eq!(0, microvmi.seek(SeekFrom::End(i64::MIN))?);
+        assert_eq!(0, memory.seek(SeekFrom::End(i64::MIN))?);
         Ok(())
     }
 
@@ -204,19 +198,16 @@ mod tests {
         // create microvmi with mock driver
         let mock_introspectable = MockIntrospectable::new();
         let max_addr: u64 = 1000;
-        let mut microvmi = Microvmi {
-            drv: Box::new(mock_introspectable),
-            pos: 0,
-            max_addr,
-        };
+        let drv = Rc::new(RefCell::new(Box::new(mock_introspectable)));
+        let mut memory = Memory::new(drv).unwrap();
         // seek current below 0 should saturate at 0
-        assert_eq!(0, microvmi.seek(SeekFrom::Current(-5))?);
+        assert_eq!(0, memory.seek(SeekFrom::Current(-5))?);
         // seek current should move the cursor
-        assert_eq!(50, microvmi.seek(SeekFrom::Current(50))?);
-        assert_eq!(49, microvmi.seek(SeekFrom::Current(-1))?);
-        assert_eq!(59, microvmi.seek(SeekFrom::Current(10))?);
+        assert_eq!(50, memory.seek(SeekFrom::Current(50))?);
+        assert_eq!(49, memory.seek(SeekFrom::Current(-1))?);
+        assert_eq!(59, memory.seek(SeekFrom::Current(10))?);
         // seek current beyond max_addr should saturate at max_addr
-        assert_eq!(max_addr, microvmi.seek(SeekFrom::Current(i64::MAX))?);
+        assert_eq!(max_addr, memory.seek(SeekFrom::Current(i64::MAX))?);
         Ok(())
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -160,13 +160,15 @@ impl Seek for PaddedMemory {
 mod tests {
     use super::*;
 
+    // Seek
     #[test]
     fn test_seek_start() -> Result<()> {
-        // create microvmi with mock driver
-        let mock_introspectable = MockIntrospectable::new();
         let max_addr: u64 = 1000;
-        let drv = Rc::new(RefCell::new(Box::new(mock_introspectable)));
-        let mut memory = Memory::new(drv).unwrap();
+        let mut mock_introspectable = MockIntrospectable::new();
+        mock_introspectable
+            .expect_get_max_physical_addr()
+            .returning(move || Ok(max_addr));
+        let mut memory = Memory::new(Rc::new(RefCell::new(Box::new(mock_introspectable)))).unwrap();
         // seek 0 doesn't move position
         assert_eq!(0, memory.seek(SeekFrom::Start(0))?);
         // seek beyond max_addr saturates at max_addr
@@ -176,11 +178,12 @@ mod tests {
 
     #[test]
     fn test_seek_end() -> Result<()> {
-        // create microvmi with mock driver
-        let mock_introspectable = MockIntrospectable::new();
         let max_addr: u64 = 1000;
-        let drv = Rc::new(RefCell::new(Box::new(mock_introspectable)));
-        let mut memory = Memory::new(drv).unwrap();
+        let mut mock_introspectable = MockIntrospectable::new();
+        mock_introspectable
+            .expect_get_max_physical_addr()
+            .returning(move || Ok(max_addr));
+        let mut memory = Memory::new(Rc::new(RefCell::new(Box::new(mock_introspectable)))).unwrap();
         // seek end should move to max_addr
         assert_eq!(max_addr, memory.seek(SeekFrom::End(0))?);
         // seek end beyond should saturates to max_addr
@@ -194,11 +197,12 @@ mod tests {
 
     #[test]
     fn test_seek_current() -> Result<()> {
-        // create microvmi with mock driver
-        let mock_introspectable = MockIntrospectable::new();
         let max_addr: u64 = 1000;
-        let drv = Rc::new(RefCell::new(Box::new(mock_introspectable)));
-        let mut memory = Memory::new(drv).unwrap();
+        let mut mock_introspectable = MockIntrospectable::new();
+        mock_introspectable
+            .expect_get_max_physical_addr()
+            .returning(move || Ok(max_addr));
+        let mut memory = Memory::new(Rc::new(RefCell::new(Box::new(mock_introspectable)))).unwrap();
         // seek current below 0 should saturate at 0
         assert_eq!(0, memory.seek(SeekFrom::Current(-5))?);
         // seek current should move the cursor

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -72,9 +72,7 @@ impl Seek for Microvmi {
                 self.seek(SeekFrom::Current(i64::try_from(p).unwrap_or(i64::MAX)))?;
             }
             SeekFrom::End(p) => {
-                self.pos = self.drv.get_max_physical_addr().map_err(|_| {
-                    Error::new(ErrorKind::Other, "Failed to get maximum physical address")
-                })?;
+                self.pos = self.max_addr;
                 self.seek(SeekFrom::Current(p))?;
             }
             SeekFrom::Current(p) => {
@@ -83,11 +81,8 @@ impl Seek for Microvmi {
                 } else {
                     self.pos = self.pos.saturating_sub(p.unsigned_abs());
                 }
-                let max_addr = self.drv.get_max_physical_addr().map_err(|_| {
-                    Error::new(ErrorKind::Other, "Failed to get maximum physical address")
-                })?;
-                if self.pos > max_addr {
-                    self.pos = max_addr;
+                if self.pos > self.max_addr {
+                    self.pos = self.max_addr;
                 }
             }
         };

--- a/src/microvmi.rs
+++ b/src/microvmi.rs
@@ -13,6 +13,7 @@ use driver::kvm::Kvm;
 use driver::virtualbox::VBox;
 #[cfg(feature = "xen")]
 use driver::xen::Xen;
+use std::error::Error;
 
 /// Main struct to interact with the library
 pub struct Microvmi {
@@ -84,6 +85,18 @@ impl Microvmi {
                 };
             }
         }
+    }
+
+    pub fn get_max_physical_addr(&self) -> Result<u64, Box<dyn Error>> {
+        Ok(self.drv.get_max_physical_addr()?)
+    }
+
+    pub fn pause(&mut self) -> Result<(), Box<dyn Error>> {
+        Ok(self.drv.pause()?)
+    }
+
+    pub fn resume(&mut self) -> Result<(), Box<dyn Error>> {
+        Ok(self.drv.resume()?)
     }
 }
 

--- a/src/microvmi.rs
+++ b/src/microvmi.rs
@@ -6,13 +6,13 @@ use kvmi::create_kvmi;
 
 use crate::api::Introspectable;
 use crate::api::{DriverInitParam, DriverType};
-use crate::errors::MicrovmiError;
 #[cfg(feature = "kvm")]
-use driver::kvm::Kvm;
+use crate::driver::kvm::Kvm;
 #[cfg(feature = "virtualbox")]
-use driver::virtualbox::VBox;
+use crate::driver::virtualbox::VBox;
 #[cfg(feature = "xen")]
-use driver::xen::Xen;
+use crate::driver::xen::Xen;
+use crate::errors::MicrovmiError;
 use std::error::Error;
 
 /// Main struct to interact with the library

--- a/src/microvmi.rs
+++ b/src/microvmi.rs
@@ -4,8 +4,8 @@ use enum_iterator::IntoEnumIterator;
 #[cfg(feature = "kvm")]
 use kvmi::create_kvmi;
 
-use crate::api::Introspectable;
 use crate::api::{DriverInitParam, DriverType};
+use crate::api::{Introspectable, Registers};
 #[cfg(feature = "kvm")]
 use crate::driver::kvm::Kvm;
 #[cfg(feature = "virtualbox")]
@@ -84,12 +84,20 @@ impl Microvmi {
         self.drv.borrow().get_max_physical_addr()
     }
 
+    pub fn read_registers(&self, vcpu: u16) -> Result<Registers, Box<dyn Error>> {
+        self.drv.borrow().read_registers(vcpu)
+    }
+
     pub fn pause(&mut self) -> Result<(), Box<dyn Error>> {
         self.drv.borrow_mut().resume()
     }
 
     pub fn resume(&mut self) -> Result<(), Box<dyn Error>> {
         self.drv.borrow_mut().resume()
+    }
+
+    pub fn get_driver_type(&self) -> DriverType {
+        self.drv.borrow().get_driver_type()
     }
 }
 

--- a/src/microvmi.rs
+++ b/src/microvmi.rs
@@ -14,6 +14,7 @@ use crate::driver::virtualbox::VBox;
 use crate::driver::xen::Xen;
 use crate::errors::MicrovmiError;
 use crate::memory::Memory;
+use crate::memory::PaddedMemory;
 use std::cell::RefCell;
 use std::error::Error;
 use std::rc::Rc;
@@ -23,6 +24,7 @@ pub struct Microvmi {
     // runtime VMI driver
     pub(crate) drv: Rc<RefCell<Box<dyn Introspectable>>>,
     pub memory: Memory,
+    pub padded_memory: PaddedMemory,
 }
 
 impl Microvmi {
@@ -74,6 +76,7 @@ impl Microvmi {
         Ok(Microvmi {
             drv: ref_drv.clone(),
             memory: Memory::new(ref_drv.clone())?,
+            padded_memory: PaddedMemory::new(ref_drv.clone())?,
         })
     }
 

--- a/src/microvmi.rs
+++ b/src/microvmi.rs
@@ -21,8 +21,6 @@ pub struct Microvmi {
     pub(crate) drv: Box<dyn Introspectable>,
     // position in the physical memory (seek)
     pub(crate) pos: u64,
-    // maximum physical address
-    pub(crate) max_addr: u64,
 }
 
 impl Microvmi {
@@ -55,16 +53,7 @@ impl Microvmi {
                 for drv_type in DriverType::into_enum_iter() {
                     // try to init
                     match init_driver(domain_name, drv_type, init_option.clone()) {
-                        Ok(drv) => {
-                            return {
-                                let max_addr = drv.get_max_physical_addr()?;
-                                Ok(Microvmi {
-                                    drv,
-                                    pos: 0,
-                                    max_addr,
-                                })
-                            }
-                        }
+                        Ok(drv) => return { Ok(Microvmi { drv, pos: 0 }) },
                         Err(e) => {
                             debug!("{:?} driver initialization failed: {}", drv_type, e);
                             continue;
@@ -75,14 +64,7 @@ impl Microvmi {
             }
             Some(drv_type) => {
                 let drv = init_driver(domain_name, drv_type, init_option)?;
-                return {
-                    let max_addr = drv.get_max_physical_addr()?;
-                    Ok(Microvmi {
-                        drv,
-                        pos: 0,
-                        max_addr,
-                    })
-                };
+                return { Ok(Microvmi { drv, pos: 0 }) };
             }
         }
     }

--- a/src/microvmi.rs
+++ b/src/microvmi.rs
@@ -53,7 +53,7 @@ impl Microvmi {
                 for drv_type in DriverType::into_enum_iter() {
                     // try to init
                     match init_driver(domain_name, drv_type, init_option.clone()) {
-                        Ok(drv) => return { Ok(Microvmi { drv, pos: 0 }) },
+                        Ok(drv) => return Ok(Microvmi { drv, pos: 0 }),
                         Err(e) => {
                             debug!("{:?} driver initialization failed: {}", drv_type, e);
                             continue;
@@ -64,21 +64,21 @@ impl Microvmi {
             }
             Some(drv_type) => {
                 let drv = init_driver(domain_name, drv_type, init_option)?;
-                return { Ok(Microvmi { drv, pos: 0 }) };
+                Ok(Microvmi { drv, pos: 0 })
             }
         }
     }
 
     pub fn get_max_physical_addr(&self) -> Result<u64, Box<dyn Error>> {
-        Ok(self.drv.get_max_physical_addr()?)
+        self.drv.get_max_physical_addr()
     }
 
     pub fn pause(&mut self) -> Result<(), Box<dyn Error>> {
-        Ok(self.drv.pause()?)
+        self.drv.pause()
     }
 
     pub fn resume(&mut self) -> Result<(), Box<dyn Error>> {
-        Ok(self.drv.resume()?)
+        self.drv.resume()
     }
 }
 

--- a/src/microvmi.rs
+++ b/src/microvmi.rs
@@ -1,0 +1,112 @@
+//! This module defines the Microvmi struct which should be the entrypoint to interact with libmicrovmi
+
+use enum_iterator::IntoEnumIterator;
+#[cfg(feature = "kvm")]
+use kvmi::create_kvmi;
+
+use crate::api::Introspectable;
+use crate::api::{DriverInitParam, DriverType};
+use crate::errors::MicrovmiError;
+#[cfg(feature = "kvm")]
+use driver::kvm::Kvm;
+#[cfg(feature = "virtualbox")]
+use driver::virtualbox::VBox;
+#[cfg(feature = "xen")]
+use driver::xen::Xen;
+
+/// Main struct to interact with the library
+pub struct Microvmi {
+    // runtime VMI driver
+    pub(crate) drv: Box<dyn Introspectable>,
+    // position in the physical memory (seek)
+    pub(crate) pos: u64,
+    // maximum physical address
+    pub(crate) max_addr: u64,
+}
+
+impl Microvmi {
+    /// Initializes a new Microvmi instance
+    ///
+    /// # Arguments
+    ///
+    /// * `domain_name` - The domain name
+    /// * `driver_type` - The driver type to initialize. None will attempt to initialize every driver avaiable
+    /// * `init_option` - Initialization parameters for the driver.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use self::microvmi::Microvmi;
+    /// use crate::api::{DriverType, DriverInitParam};
+    /// Microvmi::new("win10", None, None);
+    /// Microvmi::new("win10", Some(DriverType::Xen), None);
+    /// Microvmi::new("win10", Some(DriverType::KVM), Some(DriverInitParam::KVMiSocket("/tmp/introspector".to_string())));
+    /// ```
+    pub fn new(
+        domain_name: &str,
+        driver_type: Option<DriverType>,
+        init_option: Option<DriverInitParam>,
+    ) -> Result<Microvmi, MicrovmiError> {
+        info!("Microvmi init");
+        match driver_type {
+            None => {
+                // for each possible DriverType
+                for drv_type in DriverType::into_enum_iter() {
+                    // try to init
+                    match init_driver(domain_name, drv_type, init_option.clone()) {
+                        Ok(drv) => {
+                            return {
+                                let max_addr = drv.get_max_physical_addr()?;
+                                Ok(Microvmi {
+                                    drv,
+                                    pos: 0,
+                                    max_addr,
+                                })
+                            }
+                        }
+                        Err(e) => {
+                            debug!("{:?} driver initialization failed: {}", drv_type, e);
+                            continue;
+                        }
+                    }
+                }
+                Err(MicrovmiError::NoDriverAvailable)
+            }
+            Some(drv_type) => {
+                let drv = init_driver(domain_name, drv_type, init_option)?;
+                return {
+                    let max_addr = drv.get_max_physical_addr()?;
+                    Ok(Microvmi {
+                        drv,
+                        pos: 0,
+                        max_addr,
+                    })
+                };
+            }
+        }
+    }
+}
+
+/// Initialize a given driver type
+/// return None if the requested driver has not been compiled in libmicrovmi
+fn init_driver(
+    _domain_name: &str,
+    driver_type: DriverType,
+    _init_option: Option<DriverInitParam>,
+) -> Result<Box<dyn Introspectable>, MicrovmiError> {
+    #[allow(clippy::match_single_binding)]
+    match driver_type {
+        #[cfg(feature = "kvm")]
+        DriverType::KVM => Ok(Box::new(Kvm::new(
+            _domain_name,
+            create_kvmi(),
+            _init_option,
+        )?)),
+        #[cfg(feature = "virtualbox")]
+        DriverType::VirtualBox => Ok(Box::new(VBox::new(_domain_name, _init_option)?)),
+        #[cfg(feature = "xen")]
+        DriverType::Xen => Ok(Box::new(Xen::new(_domain_name, _init_option)?)),
+        #[allow(unreachable_patterns)]
+        _ => Err(MicrovmiError::DriverNotCompiled(driver_type)),
+    }
+}


### PR DESCRIPTION
This PR implements the memory as a file descriptor, using Rust standard traits
- `Read`
- `Write`
- `Seek`

A second memory object is implemented to handle "padded" memory reads, useful for Volatility.

Some unit tests have been implemented for the seek implementation.