### PR TITLE
clippy: allow upper case acronyms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Click on this [book 📖](https://libmicrovmi.github.io/) to find our project documentation.
 
+#![allow(clippy::upper_case_acronyms)]
+
 pub mod api;
 pub mod capi;
 mod driver;


### PR DESCRIPTION
fix clippy warning