### PR TITLE
Refactor driver initialization parameters API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
         working-directory: python
 
       - name: smoke test
-        run: python3 -c 'from microvmi import Microvmi, DriverType, DriverInitParam'
+        run: python3 -c 'from microvmi import Microvmi, DriverType, CommonInitParamsPy, DriverInitParamsPy, KVMInitParamsPy'
 
       # setup docker cache to speedup rest of the job
       - name: Docker Layer Caching

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ntapi = { version = "0.3", optional = true }
 vid-sys = { version = "=0.3.0", features = ["deprecated-apis"], optional = true }
 
 [dev-dependencies]
+utilities = { path = "utilities" }
 ctrlc = "3.1"
 clap = "2.33"
 colored = "2.0"

--- a/c_examples/mem-dump.c
+++ b/c_examples/mem-dump.c
@@ -44,7 +44,13 @@ int main(int argc, char* argv[]) {
     }
     microvmi_envlogger_init();
     const char* init_error = NULL;
-    void* driver = microvmi_init(argv[1], NULL, NULL, &init_error);
+    void* vm_name = argv[1];
+    DriverInitParamsFFI init_params = {
+        .common = {
+            .vm_name = vm_name
+        }
+    };
+    void* driver = microvmi_init(NULL, &init_params, &init_error);
     if (!driver) {
         fprintf(stderr, "%s\n", init_error);
         rs_cstring_free((char*)init_error);

--- a/c_examples/pause.c
+++ b/c_examples/pause.c
@@ -32,7 +32,13 @@ int main(int argc, char* argv[]) {
     }
     microvmi_envlogger_init();
     const char* init_error = NULL;
-    void* driver = microvmi_init(argv[1], NULL, NULL, &init_error);
+        void* vm_name = argv[1];
+        DriverInitParamsFFI init_params = {
+            .common = {
+                .vm_name = vm_name
+            }
+        };
+    void* driver = microvmi_init(NULL, &init_params, &init_error);
     if (!driver) {
         fprintf(stderr, "%s\n", init_error);
         rs_cstring_free((char*)init_error);

--- a/c_examples/regs-dump.c
+++ b/c_examples/regs-dump.c
@@ -42,7 +42,13 @@ int main(int argc, char* argv[]) {
     }
     microvmi_envlogger_init();
     const char* init_error = NULL;
-    void* driver = microvmi_init(argv[1], NULL, NULL, &init_error);
+    void* vm_name = argv[1];
+    DriverInitParamsFFI init_params = {
+        .common = {
+            .vm_name = vm_name
+        }
+    };
+    void* driver = microvmi_init(NULL, &init_params, &init_error);
     if (!driver) {
         fprintf(stderr, "%s\n", init_error);
         rs_cstring_free((char*)init_error);

--- a/doc/src/reference/python_api.md
+++ b/doc/src/reference/python_api.md
@@ -3,24 +3,45 @@
 ### Initializing libmicrovmi
 
 ~~~Python
-from microvmi import Microvmi
+from microvmi import Microvmi, DriverInitParamsPy, CommonInitParamsPy
 
-micro = Microvmi("Windows10")
+# setup common params
+common = CommonInitParamsPy()
+common.vm_name = "windows10"
+# setup main init_params
+init_params = DriverInitParamsPy()
+init_params.common = common
+micro = Microvmi(None, init_params)
 ~~~
 
 ### Specifying the hypervisor
 
 ~~~Python
-from microvmi import Microvmi, DriverType
+from microvmi import Microvmi, DriverType, DriverInitParamsPy, CommonInitParamsPy
 
-micro = Microvmi("Windows10", DriverType.XEN)
+# setup common params
+common = CommonInitParamsPy()
+common.vm_name = "windows10"
+# setup main init_params
+init_params = DriverInitParamsPy()
+init_params.common = common
+micro = Microvmi(DriverType.XEN, init_params)
 ~~~
 
 ### Adding driver initialization parameters
 
 ~~~Python
-from microvmi import Microvmi, DriverType, DriverInitParam
+from microvmi import Microvmi, DriverInitParamsPy, CommonInitParamsPy, KVMInitParamsPy
 
-init_param = DriverInitParam.kvmi_unix_socket("/tmp/introspector")
-micro = Microvmi("Windows10", DriverType.KVM, init_param)
+# setup common params
+common = CommonInitParamsPy()
+common.vm_name = "windows10"
+# setup kvm params
+kvm = KVMInitParamsPy()
+kvm.unix_socket = "/tmp/introspector"
+# setup main init_params
+init_params = DriverInitParamsPy()
+init_params.common = common
+init_params.kvm = kvm
+micro = Microvmi(DriverType.KVM, init_params)
 ~~~

--- a/doc/src/tutorial/integration/volatility3.md
+++ b/doc/src/tutorial/integration/volatility3.md
@@ -39,15 +39,19 @@ venv/lib/python3.7/site-packages/microvmi/volatility
 
 The libmicrovmi handler for volatility is a URL handler with the following syntax:
 
-    vmi://[hypervisor]/vm_name
+    vmi://[hypervisor]/?param1=value1...
 
 The hypervisor part is optional. If not specified, it will default to try every builtin driver available.
 
 Additional driver parameters can be specified.
 
+To pass the VM name:
+
+    vmi:///?vm_name=windows10
+
 To pass the KVMi socket:
 
-    vmi:///vm_name?kvmi_unix_socket=/tmp/introspector
+    vmi:///?vm_name=windows10&kvm_unix_socket=/tmp/introspector
 
 ## Running volatility3
 
@@ -57,7 +61,7 @@ Let's put all of this together and run volatility3 combined with libmicrovmi.
 - `--single-location vmi://` url
 
 ~~~
-(venv) $ vol -p <plugin_dir> --single-location vmi:///vm_name <volatility plugin>
+(venv) $ vol -p <plugin_dir> --single-location vmi:///?vm_name=windows10 <volatility plugin>
 ~~~
 
 ### Example listing processes on Xen
@@ -65,12 +69,6 @@ Let's put all of this together and run volatility3 combined with libmicrovmi.
 ~~~bash
 (venv) $ sudo -E ./venv/bin/vol \  # running volatility3 as root (required by the Xen driver)
     -p venv/lib/python3.7/site-packages/microvmi/volatility \  # path to the microvmi connection plugin
-    --single-location vmi:///winxp \  # specify the resource location
+    --single-location vmi:///?vm_name=winxp \  # specify the resource location
     windows.pslist.PsList  # volatility's pslist plugin
 ~~~
-
-🎥 [asciicast](https://asciinema.org/a/6YOXUkEwt53uYcU5rXxoWaFLq)
-
-### Example listing processes on KVM
-
-🎥 [asciicast](https://asciinema.org/a/DTyjM0rnq26RYbFX7hbS7jXvP)

--- a/examples/cr-events.rs
+++ b/examples/cr-events.rs
@@ -5,9 +5,9 @@ use std::time::Instant;
 use clap::{App, Arg, ArgMatches};
 use colored::*;
 
+use microvmi::api::events::{CrType, EventType, InterceptType};
 use microvmi::api::params::DriverInitParams;
-use microvmi::api::{CrType, EventType, InterceptType, Introspectable};
-
+use microvmi::api::Introspectable;
 use utilities::Clappable;
 
 fn parse_args() -> ArgMatches<'static> {

--- a/examples/cr-events.rs
+++ b/examples/cr-events.rs
@@ -5,14 +5,17 @@ use std::time::Instant;
 use clap::{App, Arg, ArgMatches};
 use colored::*;
 
-use microvmi::api::{CrType, DriverInitParam, EventType, InterceptType, Introspectable};
+use microvmi::api::params::DriverInitParams;
+use microvmi::api::{CrType, EventType, InterceptType, Introspectable};
+
+use utilities::Clappable;
 
 fn parse_args() -> ArgMatches<'static> {
     App::new(file!())
         .version("0.3")
         .author("Mathieu Tarral")
         .about("Watches control register VMI events")
-        .arg(Arg::with_name("vm_name").index(1).required(true))
+        .args(DriverInitParams::to_clap_args().as_ref())
         .arg(
             Arg::with_name("register")
                 .multiple(true)
@@ -20,14 +23,6 @@ fn parse_args() -> ArgMatches<'static> {
                 .short("r")
                 .default_value("3")
                 .help("control register to intercept. Possible values: [0 3 4]"),
-        )
-        .arg(
-            Arg::with_name("kvmi_socket")
-                .short("k")
-                .takes_value(true)
-                .help(
-                "pass additional KVMi socket initialization parameter required for the KVM driver",
-            ),
         )
         .get_matches()
 }
@@ -71,7 +66,6 @@ fn main() {
 
     let matches = parse_args();
 
-    let domain_name = matches.value_of("vm_name").unwrap();
     let registers: Vec<_> = matches.values_of("register").unwrap().collect();
 
     let vec_cr = get_cr(registers);
@@ -85,11 +79,9 @@ fn main() {
     .expect("Error setting Ctrl-C handler");
 
     println!("Initialize Libmicrovmi");
-    let init_option = matches
-        .value_of("kvmi_socket")
-        .map(|socket| DriverInitParam::KVMiSocket(socket.into()));
+    let init_params = DriverInitParams::from_matches(&matches);
     let mut drv: Box<dyn Introspectable> =
-        microvmi::init(domain_name, None, init_option).expect("Failed to init libmicrovmi");
+        microvmi::init(None, Some(init_params)).expect("Failed to init libmicrovmi");
 
     // enable control register interception
     toggle_cr_intercepts(&mut drv, &vec_cr, true);

--- a/examples/interrupt-events.rs
+++ b/examples/interrupt-events.rs
@@ -2,24 +2,19 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{App, ArgMatches};
 use colored::*;
 
-use microvmi::api::{DriverInitParam, EventReplyType, EventType, InterceptType, Introspectable};
+use microvmi::api::params::DriverInitParams;
+use microvmi::api::{EventReplyType, EventType, InterceptType, Introspectable};
+
+use utilities::Clappable;
 
 fn parse_args() -> ArgMatches<'static> {
     App::new(file!())
         .version("0.1")
         .about("Watches interrupt VMI events")
-        .arg(Arg::with_name("vm_name").index(1).required(true))
-        .arg(
-            Arg::with_name("kvmi_socket")
-                .short("k")
-                .takes_value(true)
-                .help(
-                "pass additional KVMi socket initialization parameter required for the KVM driver",
-            ),
-        )
+        .args(DriverInitParams::to_clap_args().as_ref())
         .get_matches()
 }
 
@@ -42,11 +37,6 @@ fn main() {
 
     let matches = parse_args();
 
-    let domain_name = matches.value_of("vm_name").unwrap();
-
-    let init_option = matches
-        .value_of("kvmi_socket")
-        .map(|socket| DriverInitParam::KVMiSocket(socket.into()));
     // set CTRL-C handler
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
@@ -56,8 +46,9 @@ fn main() {
     .expect("Error setting Ctrl-C handler");
 
     println!("Initialize Libmicrovmi");
+    let init_params = DriverInitParams::from_matches(&matches);
     let mut drv: Box<dyn Introspectable> =
-        microvmi::init(domain_name, None, init_option).expect("Failed to init libmicrovmi");
+        microvmi::init(None, Some(init_params)).expect("Failed to init libmicrovmi");
 
     //Enable int3 interception
     toggle_int3_interception(&mut drv, true);

--- a/examples/interrupt-events.rs
+++ b/examples/interrupt-events.rs
@@ -5,9 +5,9 @@ use std::time::Instant;
 use clap::{App, ArgMatches};
 use colored::*;
 
+use microvmi::api::events::{EventReplyType, EventType, InterceptType};
 use microvmi::api::params::DriverInitParams;
-use microvmi::api::{EventReplyType, EventType, InterceptType, Introspectable};
-
+use microvmi::api::Introspectable;
 use utilities::Clappable;
 
 fn parse_args() -> ArgMatches<'static> {

--- a/examples/mem-events.rs
+++ b/examples/mem-events.rs
@@ -1,12 +1,13 @@
-use clap::{App, Arg, ArgMatches};
+use clap::{App, ArgMatches};
 use colored::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use microvmi::api::{
-    Access, DriverInitParam, EventReplyType, EventType, InterceptType, Introspectable,
-};
+use microvmi::api::params::DriverInitParams;
+use microvmi::api::{Access, EventReplyType, EventType, InterceptType, Introspectable};
+
+use utilities::Clappable;
 
 const PAGE_SIZE: usize = 4096;
 
@@ -14,7 +15,7 @@ fn parse_args() -> ArgMatches<'static> {
     App::new(file!())
         .version("0.1")
         .about("Watches memory VMI events")
-        .arg(Arg::with_name("vm_name").index(1).required(true))
+        .args(DriverInitParams::to_clap_args().as_ref())
         .get_matches()
 }
 
@@ -37,8 +38,6 @@ fn main() {
 
     let matches = parse_args();
 
-    let domain_name = matches.value_of("vm_name").unwrap();
-
     // set CTRL-C handler
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
@@ -48,11 +47,9 @@ fn main() {
     .expect("Error setting Ctrl-C handler");
 
     println!("Initialize Libmicrovmi");
-    let init_option = matches
-        .value_of("kvmi_socket")
-        .map(|socket| DriverInitParam::KVMiSocket(socket.into()));
+    let init_params = DriverInitParams::from_matches(&matches);
     let mut drv: Box<dyn Introspectable> =
-        microvmi::init(domain_name, None, init_option).expect("Failed to init libmicrovmi");
+        microvmi::init(None, Some(init_params)).expect("Failed to init libmicrovmi");
     println!("Listen for memory events...");
     // record elapsed time
     let start = Instant::now();

--- a/examples/mem-events.rs
+++ b/examples/mem-events.rs
@@ -1,12 +1,13 @@
-use clap::{App, ArgMatches};
-use colored::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use microvmi::api::params::DriverInitParams;
-use microvmi::api::{Access, EventReplyType, EventType, InterceptType, Introspectable};
+use clap::{App, ArgMatches};
+use colored::*;
 
+use microvmi::api::events::{EventReplyType, EventType, InterceptType};
+use microvmi::api::params::DriverInitParams;
+use microvmi::api::{Access, Introspectable};
 use utilities::Clappable;
 
 const PAGE_SIZE: usize = 4096;

--- a/examples/msr-events.rs
+++ b/examples/msr-events.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::u32;
 
-use microvmi::api::{DriverInitParam, EventReplyType, EventType, InterceptType, Introspectable};
+use microvmi::api::params::DriverInitParams;
+use microvmi::api::{EventReplyType, EventType, InterceptType, Introspectable};
+
+use utilities::Clappable;
 
 // default set of MSRs to be intercepted
 const DEFAULT_MSR: [u32; 6] = [0x174, 0x175, 0x176, 0xc0000080, 0xc0000081, 0xc0000082];
@@ -24,26 +27,13 @@ fn parse_args() -> ArgMatches<'static> {
                 ",
         )
         .arg(
-            Arg::with_name("vm_name")
-                .help("VM name")
-                .index(1)
-                .required(true),
-        )
-        .arg(
             Arg::with_name("MSR index")
                 .help("Specific set of MSRs to be intercepted")
                 .multiple(true)
                 .takes_value(true)
                 .short("r"),
         )
-        .arg(
-            Arg::with_name("kvmi_socket")
-                .short("k")
-                .takes_value(true)
-                .help(
-                "pass additional KVMi socket initialization parameter required for the KVM driver",
-            ),
-        )
+        .args(DriverInitParams::to_clap_args().as_ref())
         .get_matches()
 }
 
@@ -68,7 +58,6 @@ fn main() {
 
     let matches = parse_args();
 
-    let domain_name = matches.value_of("vm_name").unwrap();
     let mut registers: Vec<u32> = matches.values_of("register").map_or(Vec::new(), |v| {
         v.map(|s| {
             s.parse::<u32>()
@@ -81,10 +70,6 @@ fn main() {
         registers = DEFAULT_MSR.to_vec();
     }
 
-    let init_option = matches
-        .value_of("kvmi_socket")
-        .map(|socket| DriverInitParam::KVMiSocket(socket.into()));
-
     // set CTRL-C handler
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
@@ -94,8 +79,9 @@ fn main() {
     .expect("Error setting Ctrl-C handler");
 
     println!("Initialize Libmicrovmi");
+    let init_params = DriverInitParams::from_matches(&matches);
     let mut drv: Box<dyn Introspectable> =
-        microvmi::init(domain_name, None, init_option).expect("Failed to init libmicrovmi");
+        microvmi::init(None, Some(init_params)).expect("Failed to init libmicrovmi");
 
     toggle_msr_intercepts(&mut drv, &registers, true);
 

--- a/examples/msr-events.rs
+++ b/examples/msr-events.rs
@@ -1,13 +1,14 @@
-use clap::{App, Arg, ArgMatches};
-use colored::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use std::u32;
 
-use microvmi::api::params::DriverInitParams;
-use microvmi::api::{EventReplyType, EventType, InterceptType, Introspectable};
+use clap::{App, Arg, ArgMatches};
+use colored::*;
 
+use microvmi::api::events::{EventReplyType, EventType, InterceptType};
+use microvmi::api::params::DriverInitParams;
+use microvmi::api::Introspectable;
 use utilities::Clappable;
 
 // default set of MSRs to be intercepted

--- a/examples/pause.rs
+++ b/examples/pause.rs
@@ -1,29 +1,23 @@
+use clap::{App, Arg, ArgMatches};
 use std::{thread, time};
 
-use clap::{App, Arg, ArgMatches};
+use microvmi::api::params::DriverInitParams;
+use microvmi::api::Introspectable;
 
-use microvmi::api::{DriverInitParam, Introspectable};
+use utilities::Clappable;
 
 fn parse_args() -> ArgMatches<'static> {
     App::new(file!())
         .version("0.1")
         .author("Mathieu Tarral")
         .about("Pauses and resumes the VM")
-        .arg(Arg::with_name("vm_name").index(1).required(true))
         .arg(
             Arg::with_name("timeout")
                 .takes_value(true)
                 .default_value("5")
                 .help("pause the VM during timeout seconds"),
         )
-        .arg(
-            Arg::with_name("kvmi_socket")
-                .short("k")
-                .takes_value(true)
-                .help(
-                "pass additional KVMi socket initialization parameter required for the KVM driver",
-            ),
-        )
+        .args(DriverInitParams::to_clap_args().as_ref())
         .get_matches()
 }
 
@@ -31,14 +25,12 @@ fn main() {
     env_logger::init();
 
     let matches = parse_args();
-    let domain_name = matches.value_of("vm_name").unwrap();
     let timeout = matches.value_of("timeout").unwrap().parse::<u64>().unwrap();
 
-    let init_option = matches
-        .value_of("kvmi_socket")
-        .map(|socket| DriverInitParam::KVMiSocket(socket.into()));
+    // get driver params
+    let init_params = DriverInitParams::from_matches(&matches);
     let mut drv: Box<dyn Introspectable> =
-        microvmi::init(domain_name, None, init_option).expect("Failed to init libmicrovmi");
+        microvmi::init(None, Some(init_params)).expect("Failed to init libmicrovmi");
 
     println!("pausing VM for {} seconds", timeout);
     drv.pause().expect("Failed to pause VM");

--- a/python/microvmi/__init__.py
+++ b/python/microvmi/__init__.py
@@ -1,3 +1,3 @@
 from microvmi.microvmi import DriverType, Microvmi
 
-from .pymicrovmi import DriverInitParam
+from .pymicrovmi import CommonInitParamsPy, DriverInitParamsPy, KVMInitParamsPy

--- a/python/microvmi/microvmi.py
+++ b/python/microvmi/microvmi.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from microvmi.memory import PaddedPhysicalMemoryIO, PhysicalMemoryIO
 
-from .pymicrovmi import DriverInitParam, MicrovmiExt
+from .pymicrovmi import DriverInitParamsPy, MicrovmiExt
 
 
 class DriverType(Enum):
@@ -19,20 +19,33 @@ class Microvmi:
 
     def __init__(
         self,
-        domain_name: str,
         driver_type: DriverType = None,
-        drv_init_param: DriverInitParam = None,
+        init_params: DriverInitParamsPy = None,
     ):
         """
         Initialize a Microvmi instance
 
         Args:
-            domain_name (str): the domain name
             driver_type (int, optional): the hypervisor driver type on which the library should be initialized
-            init_param (DriverInitParam, optional): additional initialization parameters for driver initialization
+            init_params (DriverInitParamsPy, optional): initialization parameters for driver initialization
+
+        Examples:
+            from microvmi import Microvmi, DriverInitParamsPy, CommonInitParamsPy, KVMInitParamsPy
+            # setup common params
+            common = CommonInitParamsPy()
+            common.vm_name = "windows10"
+            # setup kvm params
+            kvm = KVMInitParamsPy()
+            kvm.unix_socket = "/tmp/introspector"
+            # setup main init_params
+            init_params = DriverInitParamsPy()
+            init_params.common = common
+            init_params.kvm = kvm
+            # init
+            m = Microvmi(None, init_params)
         """
         drv_type_ext: Optional[int] = driver_type.value if driver_type is not None else None
-        self._micro = MicrovmiExt(domain_name, drv_type_ext, drv_init_param)
+        self._micro = MicrovmiExt(drv_type_ext, init_params)
         self._memory = PhysicalMemoryIO(self._micro)
         self._padded_memory = PaddedPhysicalMemoryIO(self._micro)
 

--- a/python/src/params.rs
+++ b/python/src/params.rs
@@ -1,0 +1,69 @@
+/// This modules defines the driver initialization parameters to be exposed from Python
+use pyo3::prelude::*;
+
+/// equivalent of `CommonInitParams` for Python
+#[pyclass]
+#[derive(Default, Debug, Clone)]
+pub struct CommonInitParamsPy {
+    #[pyo3(get, set)]
+    pub vm_name: String,
+}
+
+#[pymethods]
+impl CommonInitParamsPy {
+    #[new]
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// equivalent of `KVMInitParams` for Python
+#[pyclass]
+#[derive(Default, Debug, Clone)]
+pub struct KVMInitParamsPy {
+    #[pyo3(get, set)]
+    pub unix_socket: String,
+}
+
+#[pymethods]
+impl KVMInitParamsPy {
+    #[new]
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// equivalent of `DriverInitParams` for Python
+///
+/// # Examples
+///
+/// Usage from Python
+/// ```Python
+/// from microvmi import DriverInitParamsPy, CommonInitParamsPy, KVMInitParamsPy
+/// # setup common params
+/// common = CommonInitParamsPy()
+/// common.vm_name = "windows10"
+/// # setup kvm params
+/// kvm = KVMInitParamsPy()
+/// kvm.unix_socket = "/tmp/introspector"
+/// # finalize
+/// init_params = DriverInitParamsPy()
+/// init_params.common = common
+/// init_params.kvm = kvm
+/// ```
+#[pyclass]
+#[derive(Default, Debug, Clone)]
+pub struct DriverInitParamsPy {
+    #[pyo3(get, set)]
+    pub common: Option<CommonInitParamsPy>,
+    #[pyo3(get, set)]
+    pub kvm: Option<KVMInitParamsPy>,
+}
+
+#[pymethods]
+impl DriverInitParamsPy {
+    #[new]
+    fn new() -> Self {
+        Self::default()
+    }
+}

--- a/python/tests/unit/test_handler.py
+++ b/python/tests/unit/test_handler.py
@@ -4,49 +4,43 @@ from microvmi.volatility.vmi_handler import MicrovmiHandlerError, url_to_driver_
 
 
 def test_valid_scheme():
-    url = "vmi:///vm_name"
+    url = "vmi:///"
     url_to_driver_parameters(url)
 
 
 def test_invalid_scheme():
-    url = "http:///vm_name"
-    with pytest.raises(MicrovmiHandlerError):
-        url_to_driver_parameters(url)
-
-
-def test_empty_vm_name():
-    url = "vmi:///"
+    url = "http:///"
     with pytest.raises(MicrovmiHandlerError):
         url_to_driver_parameters(url)
 
 
 def test_parse_vm_name():
     expected = "windows10"
-    url = f"vmi:///{expected}"
-    value, *rest = url_to_driver_parameters(url)
-    assert expected == value
+    url = f"vmi:///?vm_name={expected}"
+    *rest, init_params = url_to_driver_parameters(url)
+    assert expected == init_params.common.vm_name
 
 
 def test_parse_vm_name_spaces():
     expected = "windows 10 20H1"
-    url = f"vmi:///{expected}"
-    value, *rest = url_to_driver_parameters(url)
-    assert expected == value
+    url = f"vmi:///?vm_name={expected}"
+    *rest, init_params = url_to_driver_parameters(url)
+    assert expected == init_params.common.vm_name
 
 
 def test_parse_hypervisor_none():
     expected = None
     url = "vmi:///vm_name"
-    _, value, _ = url_to_driver_parameters(url)
-    assert expected == value
+    drv_type, _ = url_to_driver_parameters(url)
+    assert expected == drv_type
 
 
 @pytest.mark.parametrize("drv_type_enum_member", [d for d in DriverType])
 def test_parse_hypervisor_each(drv_type_enum_member):
     expected = drv_type_enum_member
     url = f"vmi://{drv_type_enum_member.name}/vm_name"
-    _, value, _ = url_to_driver_parameters(url)
-    assert expected == value
+    drv_type, _ = url_to_driver_parameters(url)
+    assert expected == drv_type
 
 
 def test_parse_hypervisor_bad():
@@ -55,24 +49,17 @@ def test_parse_hypervisor_bad():
         url_to_driver_parameters(url)
 
 
-def test_parse_init_param_none():
-    expected = None
-    url = "vmi:///vm_name"
-    _, _, value = url_to_driver_parameters(url)
-    assert expected == value
-
-
 def test_parse_init_param_kvmi_socket():
     socket = "/tmp/introspector"
     # TODO: missing getter to test init_param type
-    url = f"vmi:///vm_name?kvmi_unix_socket={socket}"
-    _, _, value = url_to_driver_parameters(url)
-    assert socket == value.param_data_string
+    url = f"vmi://?kvm_unix_socket={socket}"
+    _, init_params = url_to_driver_parameters(url)
+    assert socket == init_params.kvm.unix_socket
 
 
-def test_parse_init_param_unkown_key():
+def test_parse_init_param_unknown_key():
     key = "unkown_config_key"
     socket = "/tmp/introspector"
-    url = f"vmi:///vm_name?{key}={socket}"
+    url = f"vmi://?{key}={socket}"
     with pytest.raises(MicrovmiHandlerError):
         url_to_driver_parameters(url)

--- a/src/api/events.rs
+++ b/src/api/events.rs
@@ -1,0 +1,79 @@
+use crate::api::Access;
+
+/// Various types of intercepts handled by libmicrovmi
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum InterceptType {
+    /// Intercept when value of cr register is changed by the guest
+    Cr(CrType),
+    /// Intercept when value of msr register is changed by the guest
+    Msr(u32),
+    /// Intercept when guest requests an access to a page for which the requested type of access is not granted. For example , guest tries to write on a read only page.
+    Breakpoint,
+    Pagefault,
+}
+
+/// Various types of events along with their relevant attributes being handled by this driver
+#[repr(C)]
+#[derive(Debug)]
+pub enum EventType {
+    ///Cr register interception
+    Cr {
+        ///Type of control register
+        cr_type: CrType,
+        /// new value after cr register has been intercepted by the guest.
+        new: u64,
+        /// old value before cr register has been intercepted by the guest.
+        old: u64,
+    },
+    ///Msr register interception
+    Msr {
+        ///Type of model specific register
+        msr_type: u32,
+        /// new value after msr register has been intercepted by the guest.
+        value: u64,
+    },
+    ///int3 interception
+    Breakpoint {
+        /// Physical memory address of the guest
+        gpa: u64,
+        /// instruction length. Generally it should be one. Anything other than one implies malicious guest.
+        insn_len: u8,
+    },
+    Pagefault {
+        /// Virtual memory address of the guest
+        gva: u64,
+        /// Physical memory address of the guest
+        gpa: u64,
+        /// Acsess responsible for thr pagefault
+        access: Access,
+    },
+}
+
+///Types of x86 control registers are listed here
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum CrType {
+    ///Has various control flags that modify the basic operation of the processor.
+    Cr0,
+    ///Contains a value called Page Fault Linear Address (PFLA). When a page fault occurs, the address the program attempted to access is stored in the CR2 register. CR2 register cannot be intercepted by the guest operating system.
+    Cr3,
+    ///Used in protected mode to control operations such as virtual-8086 support, enabling I/O breakpoints, page size extension and machine-check exceptions.
+    Cr4,
+}
+
+///This provides an abstraction of event which the hypervisor reports and using which we introspect the guest
+#[repr(C)]
+pub struct Event {
+    ///vcpu on which the event is detected
+    pub vcpu: u16,
+    /// Type of event detected
+    pub kind: EventType,
+}
+
+///Reply provided to the hypervisor after detecting an event
+#[repr(C)]
+#[derive(Debug)]
+pub enum EventReplyType {
+    Continue,
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,12 +1,15 @@
-pub mod params;
-
 use std::convert::TryInto;
 use std::error::Error;
 use std::ffi::{CStr, IntoStringError};
 
 use enum_iterator::IntoEnumIterator;
 
+use registers::Registers;
+
 use crate::capi::DriverInitParamFFI;
+
+pub mod params;
+pub mod registers;
 
 bitflags! {
     pub struct Access: u32 {
@@ -56,119 +59,6 @@ impl TryInto<DriverInitParam> for DriverInitParamFFI {
             ),
         })
     }
-}
-
-///an x86 segment register
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct SegmentReg {
-    ///Stores the base address of a code segment
-    pub base: u64,
-    ///Used as a threshold for offset. If offset added to base is more than limit, GP fault is generated. Otherwise a linear physical address is created.
-    pub limit: u32,
-    ///Represents 16 bit segment selector consisting of a 2-bit Requested Privilege Level (RPL), a 1-bit Table Indicator (TI), and a 13-bit index.
-    pub selector: u16,
-}
-
-/// x86 System Table Registers
-/// (GDTR, IDTR)
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct SystemTableReg {
-    /// 32/64 bits linear base address
-    pub base: u64,
-    /// 16 bits table limit
-    pub limit: u16,
-}
-
-///Represents all x86 registers on a specific VCPU
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct X86Registers {
-    /// 8 byte general purpose register.
-    pub rax: u64,
-    /// 8 byte general purpose register.
-    pub rbx: u64,
-    /// 8 byte general purpose register.
-    pub rcx: u64,
-    /// 8 byte general purpose register.
-    pub rdx: u64,
-    /// 8 byte general purpose register.
-    pub rsi: u64,
-    /// 8 byte general purpose register.
-    pub rdi: u64,
-    /// 8 byte general purpose register.
-    pub rsp: u64,
-    /// 8 byte general purpose register.
-    pub rbp: u64,
-    /// 8 byte general purpose register.
-    pub r8: u64,
-    /// 8 byte general purpose register.
-    pub r9: u64,
-    /// 8 byte general purpose register.
-    pub r10: u64,
-    /// 8 byte general purpose register.
-    pub r11: u64,
-    /// 8 byte general purpose register.
-    pub r12: u64,
-    /// 8 byte general purpose register.
-    pub r13: u64,
-    /// 8 byte general purpose register.
-    pub r14: u64,
-    /// 8 byte general purpose register.
-    pub r15: u64,
-    /// 8 byte general purpose register.
-    pub rip: u64,
-    /// 8 byte general purpose register.
-    pub rflags: u64,
-    ///Has various control flags that modify the basic operation of the processor.
-    pub cr0: u64,
-    ///Contains a value called Page Fault Linear Address (PFLA). When a page fault occurs, the address the program attempted to access is stored in the CR2 register. CR2 register cannot be intercepted by the guest operating system.
-    pub cr2: u64,
-    ///CR3 enables the processor to translate linear addresses into physical addresses by locating the page directory and page tables for the current task. Typically, the upper 20 bits of CR3 become the page directory base register (PDBR), which stores the physical address of the first page directory entry.
-    pub cr3: u64,
-    ///Used in protected mode to control operations such as virtual-8086 support, enabling I/O breakpoints, page size extension and machine-check exceptions.
-    pub cr4: u64,
-    ///Contains the 32-bit segment selector for the privilege level 0 code segment. Its index value is 0x174.
-    pub sysenter_cs: u64,
-    ///Contains the 32-bit offset into the privilege level 0 code segment to the first instruction of the selected operating procedure or routine. Its index value is 0x175.
-    pub sysenter_esp: u64,
-    ///Contains the 32-bit stack pointer for the privilege level 0 stack. Its index value is 0x176.
-    pub sysenter_eip: u64,
-    ///Extended Feature Enable Register (EFER) allows enabling the SYSCALL/SYSRET instruction, and later for entering and exiting long mode. Its index value is 0xc0000080.
-    pub msr_efer: u64,
-    ///Used to set the handler for SYSCALL and /or SYSRET instructions used for system calls. Its index value is 0xc0000081.
-    pub msr_star: u64,
-    ///Used to set the handler for SYSCALL and /or SYSRET instructions used for system calls. Its index value is 0xc0000082.
-    pub msr_lstar: u64,
-    ///Extened Feature Enable Register
-    pub efer: u64,
-    ///Advanced Programmable Interrupt Control Register
-    pub apic_base: u64,
-    ///Code segment register
-    pub cs: SegmentReg,
-    ///Data segment register
-    pub ds: SegmentReg,
-    ///Extra segment register, customizable by the programmer.
-    pub es: SegmentReg,
-    ///Points to TIB(Thread Information block) of a process.
-    pub fs: SegmentReg,
-    ///Points to TLS(Thread Local Storage) of a process.
-    pub gs: SegmentReg,
-    ///Stack Segment Register
-    pub ss: SegmentReg,
-    /// Task Register
-    pub tr: SegmentReg,
-    /// Local descriptor table register
-    pub ldt: SegmentReg,
-    pub idt: SystemTableReg,
-    pub gdt: SystemTableReg,
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub enum Registers {
-    X86(X86Registers),
 }
 
 pub const PAGE_SHIFT: u32 = 12;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,5 @@
+pub mod params;
+
 use std::convert::TryInto;
 use std::error::Error;
 use std::ffi::{CStr, IntoStringError};

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,10 +4,12 @@ use std::ffi::{CStr, IntoStringError};
 
 use enum_iterator::IntoEnumIterator;
 
+use events::{Event, EventReplyType, InterceptType};
 use registers::Registers;
 
 use crate::capi::DriverInitParamFFI;
 
+pub mod events;
 pub mod params;
 pub mod registers;
 
@@ -198,82 +200,4 @@ pub trait Introspectable {
 
     /// Return the concrete DriverType
     fn get_driver_type(&self) -> DriverType;
-}
-
-/// Various types of intercepts handled by libmicrovmi
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub enum InterceptType {
-    /// Intercept when value of cr register is changed by the guest
-    Cr(CrType),
-    /// Intercept when value of msr register is changed by the guest
-    Msr(u32),
-    /// Intercept when guest requests an access to a page for which the requested type of access is not granted. For example , guest tries to write on a read only page.
-    Breakpoint,
-    Pagefault,
-}
-
-/// Various types of events along with their relevant attributes being handled by this driver
-#[repr(C)]
-#[derive(Debug)]
-pub enum EventType {
-    ///Cr register interception
-    Cr {
-        ///Type of control register
-        cr_type: CrType,
-        /// new value after cr register has been intercepted by the guest.
-        new: u64,
-        /// old value before cr register has been intercepted by the guest.
-        old: u64,
-    },
-    ///Msr register interception
-    Msr {
-        ///Type of model specific register
-        msr_type: u32,
-        /// new value after msr register has been intercepted by the guest.
-        value: u64,
-    },
-    ///int3 interception
-    Breakpoint {
-        /// Physical memory address of the guest
-        gpa: u64,
-        /// instruction length. Generally it should be one. Anything other than one implies malicious guest.
-        insn_len: u8,
-    },
-    Pagefault {
-        /// Virtual memory address of the guest
-        gva: u64,
-        /// Physical memory address of the guest
-        gpa: u64,
-        /// Acsess responsible for thr pagefault
-        access: Access,
-    },
-}
-
-///Types of x86 control registers are listed here
-#[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum CrType {
-    ///Has various control flags that modify the basic operation of the processor.
-    Cr0,
-    ///Contains a value called Page Fault Linear Address (PFLA). When a page fault occurs, the address the program attempted to access is stored in the CR2 register. CR2 register cannot be intercepted by the guest operating system.
-    Cr3,
-    ///Used in protected mode to control operations such as virtual-8086 support, enabling I/O breakpoints, page size extension and machine-check exceptions.
-    Cr4,
-}
-
-///This provides an abstraction of event which the hypervisor reports and using which we introspect the guest
-#[repr(C)]
-pub struct Event {
-    ///vcpu on which the event is detected
-    pub vcpu: u16,
-    /// Type of event detected
-    pub kind: EventType,
-}
-
-///Reply provided to the hypervisor after detecting an event
-#[repr(C)]
-#[derive(Debug)]
-pub enum EventReplyType {
-    Continue,
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,13 +1,8 @@
-use std::convert::TryInto;
-use std::error::Error;
-use std::ffi::{CStr, IntoStringError};
-
 use enum_iterator::IntoEnumIterator;
+use std::error::Error;
 
 use events::{Event, EventReplyType, InterceptType};
 use registers::Registers;
-
-use crate::capi::DriverInitParamFFI;
 
 pub mod events;
 pub mod params;
@@ -35,33 +30,19 @@ pub enum DriverType {
     Xen,
 }
 
-/// Supports passing initialization parameters to the driver
-///
-/// Some drivers can support optional extra initialization parameters.
-///
-/// This is required to initialize the KVM driver, which needs a `domain_name` and
-/// a `kvm_socket` parameters.
-///
-/// This is equivalent to LibVMI's `vmi_init_data_type_t`
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub enum DriverInitParam {
-    KVMiSocket(String),
-}
-
-impl TryInto<DriverInitParam> for DriverInitParamFFI {
-    type Error = IntoStringError;
-
-    fn try_into(self) -> Result<DriverInitParam, Self::Error> {
-        Ok(match self {
-            DriverInitParamFFI::KVMiSocket(cstr_socket) => DriverInitParam::KVMiSocket(
-                unsafe { CStr::from_ptr(cstr_socket) }
-                    .to_owned()
-                    .into_string()?,
-            ),
-        })
-    }
-}
+// impl TryInto<DriverInitParam> for DriverInitParamFFI {
+//     type Error = IntoStringError;
+//
+//     fn try_into(self) -> Result<DriverInitParam, Self::Error> {
+//         Ok(match self {
+//             DriverInitParamFFI::KVMiSocket(cstr_socket) => DriverInitParam::KVMiSocket(
+//                 unsafe { CStr::from_ptr(cstr_socket) }
+//                     .to_owned()
+//                     .into_string()?,
+//             ),
+//         })
+//     }
+// }
 
 pub const PAGE_SHIFT: u32 = 12;
 pub const PAGE_SIZE: u32 = 4096;

--- a/src/api/params.rs
+++ b/src/api/params.rs
@@ -1,30 +1,30 @@
 /// This module describes initialization parameters for all libmicrovmi drivers
 
 /// Xen initialization parameters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum XenInitParams {}
 
 /// KVM initialization parameters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum KVMInitParams {
     UnixSocket { path: String },
 }
 
 /// VirtualBox initialization parameters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum VBoxInitParams {}
 
 /// Common initialization parameters
 ///
 /// These parameters are shared by two or more drivers, and are stored in this struct
 /// to avoid duplication and simplify the API
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CommonInitParams {
     pub vm_name: String,
 }
 
 /// This struct is used to specify the initialization parameters for all drivers
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DriverInitParams {
     pub common: Option<CommonInitParams>,
     pub xen: Option<XenInitParams>,

--- a/src/api/params.rs
+++ b/src/api/params.rs
@@ -1,0 +1,33 @@
+/// This module describes initialization parameters for all libmicrovmi drivers
+
+/// Xen initialization parameters
+#[derive(Debug, Clone)]
+pub enum XenInitParams {}
+
+/// KVM initialization parameters
+#[derive(Debug, Clone)]
+pub enum KVMInitParams {
+    UnixSocket { path: String },
+}
+
+/// VirtualBox initialization parameters
+#[derive(Debug, Clone)]
+pub enum VBoxInitParams {}
+
+/// Common initialization parameters
+///
+/// These parameters are shared by two or more drivers, and are stored in this struct
+/// to avoid duplication and simplify the API
+#[derive(Debug, Clone)]
+pub struct CommonInitParams {
+    pub vm_name: String,
+}
+
+/// This struct is used to specify the initialization parameters for all drivers
+#[derive(Default, Debug, Clone)]
+pub struct DriverInitParams {
+    pub common: Option<CommonInitParams>,
+    pub xen: Option<XenInitParams>,
+    pub kvm: Option<KVMInitParams>,
+    pub virtualbox: Option<VBoxInitParams>,
+}

--- a/src/api/params.rs
+++ b/src/api/params.rs
@@ -18,7 +18,8 @@ pub enum VBoxInitParams {}
 ///
 /// These parameters are shared by two or more drivers, and are stored in this struct
 /// to avoid duplication and simplify the API
-#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CommonInitParams {
     pub vm_name: String,
 }

--- a/src/api/registers.rs
+++ b/src/api/registers.rs
@@ -1,0 +1,112 @@
+///an x86 segment register
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct SegmentReg {
+    ///Stores the base address of a code segment
+    pub base: u64,
+    ///Used as a threshold for offset. If offset added to base is more than limit, GP fault is generated. Otherwise a linear physical address is created.
+    pub limit: u32,
+    ///Represents 16 bit segment selector consisting of a 2-bit Requested Privilege Level (RPL), a 1-bit Table Indicator (TI), and a 13-bit index.
+    pub selector: u16,
+}
+
+/// x86 System Table Registers
+/// (GDTR, IDTR)
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct SystemTableReg {
+    /// 32/64 bits linear base address
+    pub base: u64,
+    /// 16 bits table limit
+    pub limit: u16,
+}
+
+///Represents all x86 registers on a specific VCPU
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct X86Registers {
+    /// 8 byte general purpose register.
+    pub rax: u64,
+    /// 8 byte general purpose register.
+    pub rbx: u64,
+    /// 8 byte general purpose register.
+    pub rcx: u64,
+    /// 8 byte general purpose register.
+    pub rdx: u64,
+    /// 8 byte general purpose register.
+    pub rsi: u64,
+    /// 8 byte general purpose register.
+    pub rdi: u64,
+    /// 8 byte general purpose register.
+    pub rsp: u64,
+    /// 8 byte general purpose register.
+    pub rbp: u64,
+    /// 8 byte general purpose register.
+    pub r8: u64,
+    /// 8 byte general purpose register.
+    pub r9: u64,
+    /// 8 byte general purpose register.
+    pub r10: u64,
+    /// 8 byte general purpose register.
+    pub r11: u64,
+    /// 8 byte general purpose register.
+    pub r12: u64,
+    /// 8 byte general purpose register.
+    pub r13: u64,
+    /// 8 byte general purpose register.
+    pub r14: u64,
+    /// 8 byte general purpose register.
+    pub r15: u64,
+    /// 8 byte general purpose register.
+    pub rip: u64,
+    /// 8 byte general purpose register.
+    pub rflags: u64,
+    ///Has various control flags that modify the basic operation of the processor.
+    pub cr0: u64,
+    ///Contains a value called Page Fault Linear Address (PFLA). When a page fault occurs, the address the program attempted to access is stored in the CR2 register. CR2 register cannot be intercepted by the guest operating system.
+    pub cr2: u64,
+    ///CR3 enables the processor to translate linear addresses into physical addresses by locating the page directory and page tables for the current task. Typically, the upper 20 bits of CR3 become the page directory base register (PDBR), which stores the physical address of the first page directory entry.
+    pub cr3: u64,
+    ///Used in protected mode to control operations such as virtual-8086 support, enabling I/O breakpoints, page size extension and machine-check exceptions.
+    pub cr4: u64,
+    ///Contains the 32-bit segment selector for the privilege level 0 code segment. Its index value is 0x174.
+    pub sysenter_cs: u64,
+    ///Contains the 32-bit offset into the privilege level 0 code segment to the first instruction of the selected operating procedure or routine. Its index value is 0x175.
+    pub sysenter_esp: u64,
+    ///Contains the 32-bit stack pointer for the privilege level 0 stack. Its index value is 0x176.
+    pub sysenter_eip: u64,
+    ///Extended Feature Enable Register (EFER) allows enabling the SYSCALL/SYSRET instruction, and later for entering and exiting long mode. Its index value is 0xc0000080.
+    pub msr_efer: u64,
+    ///Used to set the handler for SYSCALL and /or SYSRET instructions used for system calls. Its index value is 0xc0000081.
+    pub msr_star: u64,
+    ///Used to set the handler for SYSCALL and /or SYSRET instructions used for system calls. Its index value is 0xc0000082.
+    pub msr_lstar: u64,
+    ///Extened Feature Enable Register
+    pub efer: u64,
+    ///Advanced Programmable Interrupt Control Register
+    pub apic_base: u64,
+    ///Code segment register
+    pub cs: SegmentReg,
+    ///Data segment register
+    pub ds: SegmentReg,
+    ///Extra segment register, customizable by the programmer.
+    pub es: SegmentReg,
+    ///Points to TIB(Thread Information block) of a process.
+    pub fs: SegmentReg,
+    ///Points to TLS(Thread Local Storage) of a process.
+    pub gs: SegmentReg,
+    ///Stack Segment Register
+    pub ss: SegmentReg,
+    /// Task Register
+    pub tr: SegmentReg,
+    /// Local descriptor table register
+    pub ldt: SegmentReg,
+    pub idt: SystemTableReg,
+    pub gdt: SystemTableReg,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub enum Registers {
+    X86(X86Registers),
+}

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,3 +1,4 @@
+use crate::api::params::{CommonInitParams, DriverInitParams};
 use crate::api::{DriverInitParam, DriverType, Introspectable, Registers};
 use crate::init;
 use bitflags::_core::ptr::null_mut;
@@ -47,7 +48,7 @@ pub unsafe extern "C" fn microvmi_init(
     } else {
         Some(driver_type.read())
     };
-    let init_option: Option<DriverInitParam> = if driver_init_option.is_null() {
+    let _init_option: Option<DriverInitParam> = if driver_init_option.is_null() {
         None
     } else {
         Some(
@@ -55,7 +56,16 @@ pub unsafe extern "C" fn microvmi_init(
                 .expect("Failed to convert DriverInitParam C struct to Rust equivalent"),
         )
     };
-    match init(&safe_domain_name, optional_driver_type, init_option) {
+    // TODO: just for compiling
+    let common = Some(CommonInitParams {
+        vm_name: safe_domain_name,
+    });
+    let init_params = DriverInitParams {
+        common,
+        // TODO: KVM params ?
+        ..Default::default()
+    };
+    match init(optional_driver_type, Some(init_params)) {
         Ok(driver) => Box::into_raw(Box::new(driver)) as *mut c_void,
         Err(err) => {
             if !init_error.is_null() {

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,11 +1,14 @@
-use crate::api::params::{CommonInitParams, DriverInitParams};
-use crate::api::{DriverInitParam, DriverType, Introspectable, Registers};
-use crate::init;
-use bitflags::_core::ptr::null_mut;
-use cty::{c_char, size_t, uint16_t, uint64_t, uint8_t};
 use std::convert::TryInto;
 use std::ffi::{c_void, CStr, CString};
 use std::slice;
+
+use bitflags::_core::ptr::null_mut;
+use cty::{c_char, size_t, uint16_t, uint64_t, uint8_t};
+
+use crate::api::params::{CommonInitParams, DriverInitParams};
+use crate::api::registers::Registers;
+use crate::api::{DriverInitParam, DriverType, Introspectable};
+use crate::init;
 
 /// Support passing initialization options
 /// similar to DriverInitParam, however this enum offers C API compatibility

--- a/src/driver/kvm.rs
+++ b/src/driver/kvm.rs
@@ -11,9 +11,10 @@ use std::error::Error;
 use std::mem;
 use std::vec::Vec;
 
+use crate::api::params::{DriverInitParams, KVMInitParams};
 use crate::api::{
-    Access, CrType, DriverInitParam, DriverType, Event, EventReplyType, EventType, InterceptType,
-    Introspectable, Registers, SegmentReg, SystemTableReg, X86Registers,
+    Access, CrType, DriverType, Event, EventReplyType, EventType, InterceptType, Introspectable,
+    Registers, SegmentReg, SystemTableReg, X86Registers,
 };
 use kvmi::constants::PAGE_SIZE;
 
@@ -103,20 +104,23 @@ pub struct Kvm<T: KVMIntrospectable> {
 
 #[derive(thiserror::Error, Debug)]
 pub enum KVMDriverError {
+    #[error("KVM driver requires a VM name parameter")]
+    MissingVMName,
     #[error("KVM driver initialization requires an additional socket parameter")]
     MissingSocketParameter,
 }
 
 impl<T: KVMIntrospectable> Kvm<T> {
-    pub fn new(
-        domain_name: &str,
-        mut kvmi: T,
-        init_option: Option<DriverInitParam>,
-    ) -> Result<Self, Box<dyn Error>> {
-        let DriverInitParam::KVMiSocket(socket_path) =
-            init_option.ok_or(KVMDriverError::MissingSocketParameter)?;
-        debug!("init on {} (socket: {})", domain_name, socket_path);
-        let unix_socket = SocketType::UnixSocket(socket_path);
+    pub fn new(mut kvmi: T, init_params: DriverInitParams) -> Result<Self, Box<dyn Error>> {
+        let domain_name = init_params
+            .common
+            .ok_or(KVMDriverError::MissingVMName)?
+            .vm_name;
+        let KVMInitParams::UnixSocket { path } = init_params
+            .kvm
+            .ok_or(KVMDriverError::MissingSocketParameter)?;
+        debug!("init on {} (socket: {})", domain_name, path);
+        let unix_socket = SocketType::UnixSocket(path);
         kvmi.init(unix_socket)?;
         let mut kvm = Kvm {
             kvmi,
@@ -370,6 +374,7 @@ impl<T: KVMIntrospectable> Drop for Kvm<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::params::CommonInitParams;
     use kvmi::{kvm_regs, kvm_sregs, KvmMsrs};
     use mockall::mock;
     use mockall::predicate::{eq, function};
@@ -387,9 +392,16 @@ mod tests {
         });
 
         let result = Kvm::new(
-            "some_vm",
             kvmi_mock,
-            Some(DriverInitParam::KVMiSocket("/tmp/introspector".to_string())),
+            DriverInitParams {
+                common: Some(CommonInitParams {
+                    vm_name: String::from("some_vm"),
+                }),
+                kvm: Some(KVMInitParams::UnixSocket {
+                    path: "/tmp/introspector".to_string(),
+                }),
+                ..Default::default()
+            },
         );
 
         assert!(result.is_err(), "Expected error, got ok instead!");
@@ -462,9 +474,16 @@ mod tests {
         }
 
         let result = Kvm::new(
-            "some_vm",
             kvmi_mock,
-            Some(DriverInitParam::KVMiSocket("/tmp/introspector".to_string())),
+            DriverInitParams {
+                common: Some(CommonInitParams {
+                    vm_name: String::from("some_vm"),
+                }),
+                kvm: Some(KVMInitParams::UnixSocket {
+                    path: "/tmp/introspector".to_string(),
+                }),
+                ..Default::default()
+            },
         );
 
         assert!(result.is_ok(), "Expected ok, got error instead!");

--- a/src/driver/kvm.rs
+++ b/src/driver/kvm.rs
@@ -1,9 +1,3 @@
-#[cfg(test)] // only needed for tests
-use kvmi::errors::KVMiError;
-use kvmi::{
-    kvm_dtable, kvm_regs, kvm_segment, KVMIntrospectable, KVMiCr, KVMiEvent, KVMiEventReply,
-    KVMiEventType, KVMiInterceptType, KVMiPageAccess, SocketType,
-};
 use std::convert::From;
 use std::convert::TryFrom;
 use std::convert::TryInto;
@@ -11,12 +5,19 @@ use std::error::Error;
 use std::mem;
 use std::vec::Vec;
 
+use kvmi::constants::PAGE_SIZE;
+#[cfg(test)] // only needed for tests
+use kvmi::errors::KVMiError;
+use kvmi::{
+    kvm_dtable, kvm_regs, kvm_segment, KVMIntrospectable, KVMiCr, KVMiEvent, KVMiEventReply,
+    KVMiEventType, KVMiInterceptType, KVMiPageAccess, SocketType,
+};
+
 use crate::api::params::{DriverInitParams, KVMInitParams};
+use crate::api::registers::{Registers, SegmentReg, SystemTableReg, X86Registers};
 use crate::api::{
     Access, CrType, DriverType, Event, EventReplyType, EventType, InterceptType, Introspectable,
-    Registers, SegmentReg, SystemTableReg, X86Registers,
 };
-use kvmi::constants::PAGE_SIZE;
 
 impl TryFrom<Access> for KVMiPageAccess {
     type Error = &'static str;
@@ -373,13 +374,16 @@ impl<T: KVMIntrospectable> Drop for Kvm<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::api::params::CommonInitParams;
+    use std::fmt::{Debug, Formatter};
+
     use kvmi::{kvm_regs, kvm_sregs, KvmMsrs};
     use mockall::mock;
     use mockall::predicate::{eq, function};
-    use std::fmt::{Debug, Formatter};
     use test_case::test_case;
+
+    use crate::api::params::CommonInitParams;
+
+    use super::*;
 
     #[test]
     fn test_fail_to_create_kvm_driver_if_kvmi_init_returns_error() {

--- a/src/driver/kvm.rs
+++ b/src/driver/kvm.rs
@@ -13,11 +13,10 @@ use kvmi::{
     KVMiEventType, KVMiInterceptType, KVMiPageAccess, SocketType,
 };
 
+use crate::api::events::{CrType, Event, EventReplyType, EventType, InterceptType};
 use crate::api::params::{DriverInitParams, KVMInitParams};
 use crate::api::registers::{Registers, SegmentReg, SystemTableReg, X86Registers};
-use crate::api::{
-    Access, CrType, DriverType, Event, EventReplyType, EventType, InterceptType, Introspectable,
-};
+use crate::api::{Access, DriverType, Introspectable};
 
 impl TryFrom<Access> for KVMiPageAccess {
     type Error = &'static str;

--- a/src/driver/virtualbox.rs
+++ b/src/driver/virtualbox.rs
@@ -2,24 +2,29 @@ use std::error::Error;
 
 use fdp::{RegisterType, FDP};
 
-use crate::api::{
-    DriverInitParam, DriverType, Introspectable, Registers, SegmentReg, SystemTableReg,
-    X86Registers,
-};
+use crate::api::params::DriverInitParams;
+use crate::api::{DriverType, Introspectable, Registers, SegmentReg, SystemTableReg, X86Registers};
 
-// unit struct
 #[derive(Debug)]
 pub struct VBox {
     fdp: FDP,
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum VBoxDriverError {
+    #[error("VirtualBox driver requires a VM name parameter")]
+    MissingVMName,
+}
+
 impl VBox {
-    pub fn new(
-        domain_name: &str,
-        _init_option: Option<DriverInitParam>,
-    ) -> Result<Self, Box<dyn Error>> {
+    pub fn new(init_params: DriverInitParams) -> Result<Self, Box<dyn Error>> {
+        let domain_name = init_params
+            .common
+            .ok_or(VBoxDriverError::MissingVMName)?
+            .vm_name;
+
         // init FDP
-        let fdp = FDP::new(domain_name)?;
+        let fdp = FDP::new(&domain_name)?;
         Ok(VBox { fdp })
     }
 }

--- a/src/driver/virtualbox.rs
+++ b/src/driver/virtualbox.rs
@@ -3,7 +3,8 @@ use std::error::Error;
 use fdp::{RegisterType, FDP};
 
 use crate::api::params::DriverInitParams;
-use crate::api::{DriverType, Introspectable, Registers, SegmentReg, SystemTableReg, X86Registers};
+use crate::api::registers::{Registers, SegmentReg, SystemTableReg, X86Registers};
+use crate::api::{DriverType, Introspectable};
 
 #[derive(Debug)]
 pub struct VBox {

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -1,11 +1,3 @@
-use crate::api::params::DriverInitParams;
-use crate::api::{
-    CrType, DriverType, Event, EventType, InterceptType, Introspectable, Registers, SegmentReg,
-    SystemTableReg, X86Registers,
-};
-use libc::{PROT_READ, PROT_WRITE};
-use nix::poll::PollFlags;
-use nix::poll::{poll, PollFd};
 use std::convert::Infallible;
 use std::convert::TryInto;
 use std::error::Error;
@@ -13,6 +5,10 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::mem;
 use std::num::TryFromIntError;
+
+use libc::{PROT_READ, PROT_WRITE};
+use nix::poll::PollFlags;
+use nix::poll::{poll, PollFd};
 use xenctrl::consts::{PAGE_SHIFT, PAGE_SIZE};
 use xenctrl::error::XcError;
 use xenctrl::RING_HAS_UNCONSUMED_REQUESTS;
@@ -23,6 +19,10 @@ use xenstore_rs::{XBTransaction, Xs, XsOpenFlags};
 use xenvmevent_sys::{
     vm_event_back_ring, vm_event_response_t, VM_EVENT_FLAG_VCPU_PAUSED, VM_EVENT_INTERFACE_VERSION,
 };
+
+use crate::api::params::DriverInitParams;
+use crate::api::registers::{Registers, SegmentReg, SystemTableReg, X86Registers};
+use crate::api::{CrType, DriverType, Event, EventType, InterceptType, Introspectable};
 
 #[derive(Debug)]
 pub struct Xen {

--- a/src/driver/xen.rs
+++ b/src/driver/xen.rs
@@ -20,9 +20,10 @@ use xenvmevent_sys::{
     vm_event_back_ring, vm_event_response_t, VM_EVENT_FLAG_VCPU_PAUSED, VM_EVENT_INTERFACE_VERSION,
 };
 
+use crate::api::events::{CrType, Event, EventType, InterceptType};
 use crate::api::params::DriverInitParams;
 use crate::api::registers::{Registers, SegmentReg, SystemTableReg, X86Registers};
-use crate::api::{CrType, DriverType, Event, EventType, InterceptType, Introspectable};
+use crate::api::{DriverType, Introspectable};
 
 #[derive(Debug)]
 pub struct Xen {

--- a/tests/common/config.rs
+++ b/tests/common/config.rs
@@ -1,5 +1,5 @@
 pub static VM_NAME: &str = "winxp";
-pub static VM_VCPU_COUNT: u16 = 2;
+pub static VM_VCPU_COUNT: u16 = 1;
 pub static VIRSH_URI: &str = "qemu:///system";
 pub static KVMI_SOCKET: &str = "/tmp/introspector";
 pub static TIMEOUT: u64 = 20;

--- a/tests/common/kvm.rs
+++ b/tests/common/kvm.rs
@@ -1,7 +1,8 @@
 use std::process::{Command, Stdio};
 
 use log::debug;
-use microvmi::api::{DriverInitParam, DriverType, Introspectable};
+use microvmi::api::params::{CommonInitParams, DriverInitParams, KVMInitParams};
+use microvmi::api::{DriverType, Introspectable};
 use microvmi::init;
 
 use super::config::{KVMI_SOCKET, VIRSH_URI, VM_NAME};
@@ -30,9 +31,16 @@ impl Context for KVM {
 
     fn init_driver(&self) -> Box<dyn Introspectable> {
         init(
-            VM_NAME,
             Some(DriverType::KVM),
-            Some(DriverInitParam::KVMiSocket(String::from(KVMI_SOCKET))),
+            Some(DriverInitParams {
+                common: Some(CommonInitParams {
+                    vm_name: String::from(VM_NAME),
+                }),
+                kvm: Some(KVMInitParams::UnixSocket {
+                    path: String::from(KVMI_SOCKET),
+                }),
+                ..Default::default()
+            }),
         )
         .expect("Failed to init libmicrovmi")
     }

--- a/tests/tests/events.rs
+++ b/tests/tests/events.rs
@@ -1,5 +1,7 @@
+use microvmi::api::events::{CrType, EventReplyType, EventType, InterceptType};
+use microvmi::api::Introspectable;
+
 use super::IntegrationTest;
-use microvmi::api::{CrType, EventReplyType, EventType, InterceptType, Introspectable};
 
 fn intercept_cr3_one(mut drv: Box<dyn Introspectable>) {
     for vcpu in 0..drv.get_vcpu_count().unwrap() - 1 {

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "utilities"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+microvmi = { path = ".." }
+clap = "2.33"

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -1,0 +1,45 @@
+/// This crate implements utilities and common code shared by libmicrovmi examples
+use clap::{Arg, ArgMatches};
+use microvmi::api::params::{CommonInitParams, DriverInitParams, KVMInitParams};
+
+/// This trait allows to convert a struct to Clap's command line arguments
+/// and to parse back the matches into the struct
+pub trait Clappable {
+    /// produces an equivalent of the struct as vector of Clap arguments
+    fn to_clap_args<'a, 'b>() -> Vec<Arg<'a, 'b>>;
+    /// builds a new struct from Clap matches
+    fn from_matches(matches: &ArgMatches) -> Self;
+}
+
+impl Clappable for DriverInitParams {
+    fn to_clap_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+        vec![
+            // common
+            Arg::with_name("vm_name")
+                .long("vm_name")
+                .takes_value(true)
+                .help("Driver parameter (required for Xen, KVM, VirtualBox): VM name"),
+            // kvm
+            Arg::with_name("kvm_unix_socket")
+                .long("kvm_unix_socket")
+                .takes_value(true)
+                .help("Driver parameter (required for KVM): KVM unix socket path"),
+        ]
+    }
+
+    fn from_matches(matches: &ArgMatches) -> Self {
+        let common = matches.value_of("vm_name").map(|s| CommonInitParams {
+            vm_name: String::from(s),
+        });
+        let kvm = matches
+            .value_of("kvm_unix_socket")
+            .map(|s| KVMInitParams::UnixSocket {
+                path: String::from(s),
+            });
+        DriverInitParams {
+            common,
+            kvm,
+            ..Default::default()
+        }
+    }
+}

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -43,3 +43,35 @@ impl Clappable for DriverInitParams {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Clappable;
+    use clap::App;
+    use microvmi::api::params::{DriverInitParams, KVMInitParams};
+
+    #[test]
+    fn test_common_vm_name() {
+        let cmdline = vec!["test", "--vm_name=windows10"];
+        let matches = App::new("test")
+            .args(DriverInitParams::to_clap_args().as_ref())
+            .get_matches_from(cmdline);
+        let params = DriverInitParams::from_matches(&matches);
+        assert_eq!("windows10", params.common.unwrap().vm_name)
+    }
+
+    #[test]
+    fn test_kvm_unix_socket() {
+        let cmdline = vec!["test", "--kvm_unix_socket=/tmp/introspector"];
+        let matches = App::new("test")
+            .args(DriverInitParams::to_clap_args().as_ref())
+            .get_matches_from(cmdline);
+        let params = DriverInitParams::from_matches(&matches);
+        assert_eq!(
+            KVMInitParams::UnixSocket {
+                path: String::from("/tmp/introspector")
+            },
+            params.kvm.unwrap()
+        );
+    }
+}


### PR DESCRIPTION
This PR implements the idea discussed in #197 

# TODO

- [x] adapt examples
- [x] update the C API
- [x] update the Python API

## Adapt examples

To make driver argument parsing less tedius when maintaing the examples, I created a local subcrate `utilities`, in order to share common code.

This crate exposes a trait `Clappable` which defines 2 functions to convert a struct to Clap command line arguments, and from Clap matches.

~~~rust
/// This trait allows to convert a struct to Clap's command line arguments
/// and to parse back the matches into the struct
pub trait Clappable {
    /// produces an equivalent of the struct as vector of Clap arguments
    fn to_clap_args<'a, 'b>() -> Vec<Arg<'a, 'b>>;
    /// builds a new struct from Clap matches
    fn from_matches(matches: &ArgMatches) -> Self;
}
~~~

And implementing it for `DriverInitParams`.

Then it's only a matter of importing the trait in the examples:
~~~rust
use utilities::Clappable;

    App::new(file!())
        .version("0.3")
        .author("Mathieu Tarral")
        .about("Watches control register VMI events")
        .args(DriverInitParams::to_clap_args().as_ref())

// parsing the matches
let init_params = DriverInitParams::from_matches(&matches);
// init
microvmi::init(None, Some(init_params))
~~~

## Adapt C API

~~~C
    // set vm name and pass init params
    void* vm_name = argv[1];
    DriverInitParamsFFI init_params = {
        .common = {
            .vm_name = vm_name
        }
    };
    void* driver = microvmi_init(NULL, &init_params, &init_error);
~~~

## Adapt Python API

~~~Python
            from microvmi import Microvmi, DriverInitParamsPy, CommonInitParamsPy, KVMInitParamsPy
            # setup common params
            common = CommonInitParamsPy()
            common.vm_name = "windows10"
            # setup kvm params
            kvm = KVMInitParamsPy()
            kvm.unix_socket = "/tmp/introspector"
            # setup main init_params
            init_params = DriverInitParamsPy()
            init_params.common = common
            init_params.kvm = kvm
            # init
            m = Microvmi(None, init_params)
~~~