### PR TITLE
ci: remove changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,12 +371,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo
 
-      - name: install cargo changelog
-        run: cargo install changelog
-
-      - name: generate changelog
-        run: changelog -o changelog.md
-
       - name: Create a Release
         id: create_release
         uses: actions/create-release@v1
@@ -385,7 +379,6 @@ jobs:
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
           release_name: ${{ steps.get_version.outputs.version }}
-          body_path: changelog.md
 
       - id: step_upload_url
         run: echo "::set-output name=upload_url::${{ steps.create_release.outputs.upload_url }}"


### PR DESCRIPTION
generated changelog contains all the commits and keeps growing over time
github complains that the request body is too large