### PR TITLE
cargo: upgrade xen libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ nix = "0.22.1"
 enum-iterator = "0.7.0"
 thiserror = "1.0"
 libc = { version = "0.2.58", optional = true }
-xenctrl = { version = "=0.4.5", optional = true }
-xenstore-rs = { version = "=0.3.0", optional = true }
-xenforeignmemory = { version = "=0.2.1", optional = true }
-xenevtchn = { version = "=0.1.4", optional = true }
+xenctrl = { version = "=0.4.7", optional = true }
+xenstore-rs = { version = "=0.3.2", optional = true }
+xenforeignmemory = { version = "=0.2.3", optional = true }
+xenevtchn = { version = "=0.1.6", optional = true }
 xenvmevent-sys = { version = "=0.1.3", optional = true }
 kvmi = { version = "0.4.0", optional = true }
 fdp = { version = "=0.2.5", optional = true }


### PR DESCRIPTION
fix unwrap when loading xen libraries:
https://github.com/Wenzel/xenstore/pull/8
https://github.com/Wenzel/xenevtchn/pull/11
https://github.com/Wenzel/xenctrl/pull/41
https://github.com/Wenzel/xenforeignmemory/pull/9